### PR TITLE
Expose WebSocketServerFactory's externalPort arg

### DIFF
--- a/autobahn/autobahn/wamp.py
+++ b/autobahn/autobahn/wamp.py
@@ -1018,8 +1018,8 @@ class WampServerFactory(WebSocketServerFactory, WampFactory):
    Twisted protocol used by default for WAMP servers.
    """
 
-   def __init__(self, url, debug = False, debugCodePaths = False, debugWamp = False, debugApp = False):
-      WebSocketServerFactory.__init__(self, url, protocols = ["wamp"], debug = debug, debugCodePaths = debugCodePaths)
+   def __init__(self, url, debug = False, debugCodePaths = False, debugWamp = False, debugApp = False, externalPort = None):
+      WebSocketServerFactory.__init__(self, url, protocols = ["wamp"], debug = debug, debugCodePaths = debugCodePaths, externalPort = externalPort)
       self.debugWamp = debugWamp
       self.debugApp = debugApp
 


### PR DESCRIPTION
externalPort allows a WebSocketServer to run behind a reverse
proxy. Exposing it allows WampServer to run behind a reverse
proxy as well.
