### PR TITLE
Fix for Python client in custom PubSub example

### DIFF
--- a/examples/wamp/pubsub/custom/client.py
+++ b/examples/wamp/pubsub/custom/client.py
@@ -44,12 +44,13 @@ class MyClientProtocol(WampClientProtocol):
 
    def onSessionOpen(self):
 
-      self.prefix("event", "http://resource.example.com/schema/event#")
+      self.prefix("event", "http://example.com/event/")
 
-      self.subscribe("event:foobar", self.onFoobar)
+      self.subscribe("event:foobar1", self.onFoobar)
+      self.subscribe("event:foobar2", self.onFoobar)
 
-      self.publish("event:foobar", {"name": "foo", "value": "bar", "num": 666})
-      self.publish("event:foobar", {"name": "foo", "value": "bar", "num": 666})
+      self.publish("event:foobar1", {"count": 666})
+      self.publish("event:foobar2", {"count": 67})
       self.publish("event:foobar-extended", {"name": "foo", "value": "bar", "num": 42})
       self.publish("event:foobar-limited", {"name": "foo", "value": "bar", "num": 23})
 


### PR DESCRIPTION
The JS client was correct but the Python-only client did not work with the supplied server. Corrected minor issues and client now works correctly. 
