### PR TITLE
Close access to local files

### DIFF
--- a/examples/websocket/multiproto/server2.py
+++ b/examples/websocket/multiproto/server2.py
@@ -21,7 +21,7 @@ import sys
 from twisted.internet import reactor
 from twisted.python import log
 from twisted.web.server import Site
-from twisted.web.static import File
+from twisted.web.static import Data
 
 from autobahn.websocket import WebSocketServerFactory, \
                                WebSocketServerProtocol
@@ -61,8 +61,8 @@ if __name__ == '__main__':
    factory2.protocol = Echo2ServerProtocol
    resource2 = WebSocketResource(factory2)
 
-   ## we server static files under "/" ..
-   root = File(".")
+   ## Establish a dummy root resource
+   root = Data("", "text/plain")
 
    ## and our WebSocket servers under different paths ..
    root.putChild("echo1", resource1)


### PR DESCRIPTION
This example is excellent, but the way it is implemented might lead
people to think this is how it should be done in production.  However,
since no local files are actually needed here, it is better to show
a pattern that doesn't open up access to local files.
