### PR TITLE
Print exceptions in pubsub topic handlers instead of ignoring them

### DIFF
--- a/autobahn/autobahn/wamp.py
+++ b/autobahn/autobahn/wamp.py
@@ -741,7 +741,8 @@ class WampServerProtocol(WebSocketServerProtocol, WampProtocol):
                                  self.factory._subscribeClient(self, topicUri)
                            except:
                               if self.debugWamp:
-                                 log.msg("exception during topic subscription handler")
+                                 log.msg("exception during topic subscription handler:")
+                              traceback.print_exc()
                      else:
                         if self.debugWamp:
                            log.msg("topic %s matches only by prefix and prefix match disallowed" % topicUri)
@@ -813,7 +814,8 @@ class WampServerProtocol(WebSocketServerProtocol, WampProtocol):
                                  self.factory.dispatch(topicUri, e, exclude, eligible)
                            except:
                               if self.debugWamp:
-                                 log.msg("exception during topic publication handler")
+                                 log.msg("exception during topic publication handler:")
+                              traceback.print_exc()
                      else:
                         if self.debugWamp:
                            log.msg("topic %s matches only by prefix and prefix match disallowed" % topicUri)


### PR DESCRIPTION
Silently ignoring exceptions occuring in code written by users of this library is not a good idea.
Fix some typos, too.
