### PR TITLE
Fix unicode error in authentication

### DIFF
--- a/autobahn/autobahn/wamp.py
+++ b/autobahn/autobahn/wamp.py
@@ -1758,6 +1758,8 @@ class WampCraProtocol(WampProtocol):
       """
       if authSecret is None:
          authSecret = ""
+      if isinstance(authSecret, unicode):
+          authSecret = authSecret.encode("utf-8")
       if authExtra is not None:
           authSalt = authExtra.get('salt')
           keylen = authExtra.get('keylen', 32)


### PR DESCRIPTION
When passing a unicode object as authSecret hmac.new fails, because it expects a byte type. 
