### PR TITLE
Change callable check for `WampClientProtocol.subscribe`

### DIFF
--- a/autobahn/autobahn/wamp.py
+++ b/autobahn/autobahn/wamp.py
@@ -1421,7 +1421,7 @@ class WampClientProtocol(WebSocketClientProtocol, WampProtocol):
       if type(topicUri) not in [unicode, str]:
          raise Exception("invalid type for parameter 'topicUri' - must be string (was %s)" % type(topicUri))
 
-      if type(handler) not in [types.FunctionType, types.MethodType, types.BuiltinFunctionType, types.BuiltinMethodType]:
+      if not hasattr(handler, '__call__'):
          raise Exception("invalid type for parameter 'handler' - must be a callable (was %s)" % type(handler))
 
       turi = self.prefixes.resolveOrPass(topicUri) ### PFX - keep


### PR DESCRIPTION
The current check to determine if an object is callable does not allow for callable classes.  This fixes that, as well as making it much simpler.
