### PR TITLE
Improve WebSocket subprotocol error handling

### DIFF
--- a/autobahn/autobahn/websocket.py
+++ b/autobahn/autobahn/websocket.py
@@ -3726,7 +3726,10 @@ class WebSocketClientProtocol(WebSocketProtocol):
                return self.failHandshake("HTTP Sec-WebSocket-Protocol header appears more than once in opening handshake reply")
             sp = str(self.http_headers["sec-websocket-protocol"].strip())
             if sp != "":
-               if sp not in self.factory.protocols:
+               ## if the client specified a subprotocol list, make sure the
+               ## server's subprotocol is on it
+               ##
+               if self.factory.protocols and sp not in self.factory.protocols:
                   return self.failHandshake("subprotocol selected by server (%s) not in subprotocol list requested by client (%s)" % (sp, str(self.factory.protocols)))
                else:
                   ## ok, subprotocol in use


### PR DESCRIPTION
The WebSocket client would reject server responses that specified a
subprotocol that wasn't on the client's subprotocol list. This is fine,
except for the case when the client's subprotocol list is empty.

In that case, the client should accept any server selected subprotocol,
provided that the header does not appear more than once.
