### PR TITLE
Move setup.py to upper level

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ Source Code:
 ## See: http://stackoverflow.com/a/7071358/884770
 ##
 import re
-VERSIONFILE="autobahn/_version.py"
+VERSIONFILE="autobahn/autobahn/_version.py"
 verstrline = open(VERSIONFILE, "rt").read()
 VSRE = r"^__version__ = ['\"]([^'\"]*)['\"]"
 mo = re.search(VSRE, verstrline, re.M)
@@ -67,6 +67,7 @@ setup (
       'accelerate': ["wsaccel>=0.6.2"],
       'compress': ["python-snappy>=0.5", "lz4>=0.2.1"]
    },
+   package_dir = {'autobahn': './autobahn/autobahn'},
    packages = ['autobahn'],
    zip_safe = False,
    ## http://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
Moving setup.py to upper level allow to install AutobahPython directly from git repository using pip install -e
