### PR TITLE
Travis check for install / import

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: python
+
+python:
+  - "2.6"
+  - "2.7"
+  - "3.3"
+  - "pypy"
+
+before_script:
+  - pip install Twisted
+
+script:
+  - cd autobahn
+  - python setup.py install
+  - python -c "from autobahn import *"


### PR DESCRIPTION
Hi,

This travis configuration installs and imports autobahn on python 2.6, 2.7, 3.3 and pypy after every commit (with twisted integration). Travis doesn't support 3.4 yet (thus no asyncio integration) but that will probably become available soon.

What you need to do basically is the following : 
- Merge this pull request
- Head to [travis-ci](https://travis-ci.org/) and sign in with GitHub (on the upper right)
- Go to Accounts (upper right) and sync your repos. From there you can hit the switch near the AutobahnPython repo so that the service hook gets activated.
- Optionally, you might want to add a travis status badge to the repo README with the following markdown :

```
[![Build Status](https://travis-ci.org/tavendo/AutobahnPython.png?branch=master)](https://travis-ci.org/tavendo/AutobahnPython)
```
