### PR TITLE
security patch for eligible list

### DIFF
--- a/autobahn/autobahn/wamp/broker.py
+++ b/autobahn/autobahn/wamp/broker.py
@@ -129,8 +129,8 @@ class Broker:
             for s in publish.eligible:
                if s in self._session_id_to_session:
                   eligible.append(self._session_id_to_session[s])
-            if eligible:
-               receivers = set(eligible) & receivers
+            
+            receivers = set(eligible) & receivers
 
          ## remove "excluded" receivers
          ##


### PR DESCRIPTION
if a session id is given and it doesn't exist, the message was sent to all subscribed sessions.
