### PR TITLE
BugFix - In context of twisted, when running unit tests, will get an error -

### DIFF
--- a/autobahn/autobahn/twisted/websocket.py
+++ b/autobahn/autobahn/twisted/websocket.py
@@ -197,6 +197,7 @@ class WebSocketClientProtocol(WebSocketAdapterProtocol, protocol.WebSocketClient
 
    def _onConnect(self, response):
       self.onConnect(response)
+      self.succeedHandshake()
 
 
 

--- a/autobahn/autobahn/websocket/protocol.py
+++ b/autobahn/autobahn/websocket/protocol.py
@@ -3706,6 +3706,19 @@ class WebSocketClientProtocol(WebSocketProtocol):
       pass
 
 
+   def succeedHandshake(self, res):
+      """
+      Callback after onConnect() returns successfully.
+      """
+      # # cancel any opening HS timer if present
+      ##
+      if self.openHandshakeTimeoutCall is not None:
+         if self.debugCodePaths:
+            self.factory._log("openHandshakeTimeoutCall.cancel")
+         self.openHandshakeTimeoutCall.cancel()
+         self.openHandshakeTimeoutCall = None
+
+
    def _connectionMade(self):
       """
       Called by network framework when new transport connection to server was established. Default


### PR DESCRIPTION
   Failure: twisted.trial.util.DirtyReactorAggregateError: Reactor was unclean.
   <DelayedCall 0x27b6b00 [0.934782028198s] called=0 cancelled=0 LinusWebSocketClientProtocol.onOpenHandshakeTimeout()>
This happens because onOpenHandshakeTimeout has a default of 5 seocnds, and the timer is not canceled even if
we open the websocket. Thne if your test completes within 5 seconds you'll get this error.

This Patch adds succeedHandshake() to WebSocketClientProtocol which then cancels the openHandshakeTimeoutCall.
