### PR TITLE
Allows headers dict to contain iterables

### DIFF
--- a/autobahn/autobahn/websocket/interfaces.py
+++ b/autobahn/autobahn/websocket/interfaces.py
@@ -55,6 +55,9 @@ class IWebSocketChannel(object):
             also may be ``None``) and set the given HTTP ``headers`` (e.g. cookies). ``headers``
             must be a ``dict`` with ``str`` keys and values for the HTTP header values to set.
 
+            If a given header value is a non-string iterable (e.g. list or tuple), a separate 
+            header line will be sent for each item in the iterable.
+
          If the client announced one or multiple subprotocols, the server MUST select
          one of the given list.
       """

--- a/autobahn/autobahn/websocket/protocol.py
+++ b/autobahn/autobahn/websocket/protocol.py
@@ -3214,12 +3214,19 @@ class WebSocketServerProtocol(WebSocketProtocol):
 
       ## optional, user supplied additional HTTP headers
       ##
-      ## headers from factory
-      for uh in self.factory.headers.items():
-         response += "%s: %s\x0d\x0a" % (uh[0], uh[1])
-      ## headers from onConnect
-      for uh in headers.items():
-         response += "%s: %s\x0d\x0a" % (uh[0], uh[1])
+      ## headers from factory, headers from onConnect
+      for headers_source in (self.factory.headers.items(), headers.items()):
+         for uh in headers_source:
+            if isinstance(uh[1], six.string_types):
+               header_values = [uh[1]]
+            else:
+               try:
+                  header_values = iter(uh[1])
+               except TypeError:
+                  header_values = [uh[1]]
+
+            for header_value in header_values:
+               response += "%s: %s\x0d\x0a" % (uh[0], header_value)
 
       if self.websocket_protocol_in_use is not None:
          response += "Sec-WebSocket-Protocol: %s\x0d\x0a" % str(self.websocket_protocol_in_use)


### PR DESCRIPTION
Implementing feature in #272

HTTP allows for a header to be sent multiple times with different values
(provided they could otherwise be combined into one header with an ;
character).  This is the current preferred method for setting cookies
with Set-Cookie.

Added support for provided header values as iterables, for which each
item in the iterable will be in it's own header line.  Order is
preserved, as the HTTP spec requires.

Added documentation for feature.

Ref: http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2
