### PR TITLE
Fix serialization of non-ASCII messages.

### DIFF
--- a/autobahn/autobahn/wamp/serializer.py
+++ b/autobahn/autobahn/wamp/serializer.py
@@ -177,10 +177,12 @@ finally:
          Implements :func:`autobahn.wamp.interfaces.IObjectSerializer.serialize`
          """
          s = _dumps(obj)
+         if isinstance(s, six.text_type):
+             s = s.encode('utf8')
          if self._batched:
-            return s.encode('utf8') + b'\30'
+            return s + b'\30'
          else:
-            return s.encode('utf8')
+            return s
 
 
       def unserialize(self, payload):

--- a/autobahn/autobahn/wamp/test/test_serializer.py
+++ b/autobahn/autobahn/wamp/test/test_serializer.py
@@ -65,7 +65,9 @@ def generate_test_messages():
       message.Subscribe(123456, u'com.myapp.topic1'),
       message.Subscribe(123456, u'com.myapp.topic1', match = message.Subscribe.MATCH_PREFIX),
       message.Error(message.Call.MESSAGE_TYPE, 123456, u'com.myapp.error1'),
-      message.Error(message.Call.MESSAGE_TYPE, 123456, u'com.myapp.error1', args = [1, 2, 3], kwargs = {u'foo': 23, u'bar': u'hello'})
+      message.Error(message.Call.MESSAGE_TYPE, 123456, u'com.myapp.error1', args = [1, 2, 3], kwargs = {u'foo': 23, u'bar': u'hello'}),
+      message.Call(123456, u'com.myapp.\u4f60\u597d\u4e16\u754c', args=[1, 2, 3]),
+      message.Result(123456, args=[1, 2, 3], kwargs={u'en': u'Hello World', u'jp': u'\u3053\u3093\u306b\u3061\u306f\u4e16\u754c'})
    ]
 
 


### PR DESCRIPTION
When using `ensure_ascii=False`, the `json` module from Python standard library returns a text type (`unicode` on Python 2), while `ujson` returns a UTF8-encoded byte string (`str` on Python 2). This has caused serialization failure of messages with non-ASCII characters when using `ujson`. This patch handles the potential difference between serialization backend outputs and adds appropriate test cases.
