### PR TITLE
Fix client auto-ping

### DIFF
--- a/autobahn/websocket/protocol.py
+++ b/autobahn/websocket/protocol.py
@@ -3688,6 +3688,11 @@ class WebSocketClientProtocol(WebSocketProtocol):
             self.current_frame = None
             self.websocket_version = self.version
 
+            # automatic ping/pong
+            #
+            if self.autoPingInterval:
+                self.autoPingPendingCall = txaio.call_later(self.autoPingInterval, self._sendAutoPing)
+
             # we handle this symmetrical to server-side .. that is, give the
             # client a chance to bail out .. i.e. on no subprotocol selected
             # by server


### PR DESCRIPTION
There is a auto-ping option in client factory, but client never start auto-ping. Is it a bug?