### PR TITLE
Support WSS + proxy

### DIFF
--- a/autobahn/asyncio/websocket.py
+++ b/autobahn/asyncio/websocket.py
@@ -214,6 +214,7 @@ class WebSocketClientProtocol(WebSocketAdapterProtocol, protocol.WebSocketClient
     def startTLS(self):
         raise Exception("WSS over explicit proxies not implemented")
 
+
 class WebSocketAdapterFactory(object):
     """
     Adapter class for asyncio-based WebSocket client and server factories.

--- a/autobahn/asyncio/websocket.py
+++ b/autobahn/asyncio/websocket.py
@@ -211,6 +211,8 @@ class WebSocketClientProtocol(WebSocketAdapterProtocol, protocol.WebSocketClient
         if yields(res):
             asyncio.async(res)
 
+    def startTLS(self):
+        raise Exception("WSS over explicit proxies not implemented")
 
 class WebSocketAdapterFactory(object):
     """

--- a/autobahn/twisted/websocket.py
+++ b/autobahn/twisted/websocket.py
@@ -218,10 +218,12 @@ class WebSocketClientProtocol(WebSocketAdapterProtocol, protocol.WebSocketClient
 
     def _onConnect(self, response):
         self.onConnect(response)
+
     def startTLS(self):
         self.log.debug("Starting TLS upgrade")
         self.transport.startTLS(self.factory.contextFactory)
         self.startHandshake()
+
 
 class WebSocketAdapterFactory(object):
     """

--- a/autobahn/twisted/websocket.py
+++ b/autobahn/twisted/websocket.py
@@ -222,7 +222,6 @@ class WebSocketClientProtocol(WebSocketAdapterProtocol, protocol.WebSocketClient
     def startTLS(self):
         self.log.debug("Starting TLS upgrade")
         self.transport.startTLS(self.factory.contextFactory)
-        self.startHandshake()
 
 
 class WebSocketAdapterFactory(object):

--- a/autobahn/websocket/protocol.py
+++ b/autobahn/websocket/protocol.py
@@ -3394,7 +3394,7 @@ class WebSocketClientProtocol(WebSocketProtocol):
             # HTTP version
             #
             http_version = sl[0].strip()
-            if http_version != "HTTP/1.1":
+            if not http_version in ("HTTP/1.1", "HTTP/1.0"):
                 return self.failProxyConnect("Unsupported HTTP version ('%s')" % http_version)
 
             # HTTP status code
@@ -3430,7 +3430,10 @@ class WebSocketClientProtocol(WebSocketProtocol):
 
             # now start WebSocket opening handshake
             #
-            self.startHandshake()
+            if self.factory.isSecure:
+                self.startTLS()
+            else:
+                self.startHandshake()
 
     def failProxyConnect(self, reason):
         """

--- a/autobahn/websocket/protocol.py
+++ b/autobahn/websocket/protocol.py
@@ -3432,8 +3432,7 @@ class WebSocketClientProtocol(WebSocketProtocol):
             #
             if self.factory.isSecure:
                 self.startTLS()
-            else:
-                self.startHandshake()
+            self.startHandshake()
 
     def failProxyConnect(self, reason):
         """

--- a/autobahn/websocket/protocol.py
+++ b/autobahn/websocket/protocol.py
@@ -3394,7 +3394,7 @@ class WebSocketClientProtocol(WebSocketProtocol):
             # HTTP version
             #
             http_version = sl[0].strip()
-            if not http_version in ("HTTP/1.1", "HTTP/1.0"):
+            if http_version not in ("HTTP/1.1", "HTTP/1.0"):
                 return self.failProxyConnect("Unsupported HTTP version ('%s')" % http_version)
 
             # HTTP status code


### PR DESCRIPTION
Hi. This patch allows the connectWS() method to supports proxy + WSS:// combination. It adds a new method startTLS() to the network layer, which is called after plain-text proxy interaction concludes. The twisted implementation delegates to transport.startTLS().

Additionally the SSL context passed into connectWS needs to be preserved until startTLS is called, so poke it into the factory.

When testing with Squid I found it (perhaps erroneously) returns a HTTP/1.0 response to the connect method, so this patch also relaxes that check.