### PR TITLE
WAMP Session IDs start at 1 per the RFC/spec text

### DIFF
--- a/autobahn/test/test_util.py
+++ b/autobahn/test/test_util.py
@@ -35,5 +35,14 @@ class TestIdGenerator(unittest.TestCase):
     def test_idgenerator_is_generator(self):
         "IdGenerator follows the generator protocol"
         g = IdGenerator()
-        self.assertEqual(0, next(g))
         self.assertEqual(1, next(g))
+        self.assertEqual(2, next(g))
+
+    def test_generator_wrap(self):
+        g = IdGenerator()
+        g._next = 2 ** 53 - 1  # cheat a little
+
+        v = next(g)
+        self.assertEqual(v, 2 ** 53)
+        v = next(g)
+        self.assertEqual(v, 1)

--- a/autobahn/util.py
+++ b/autobahn/util.py
@@ -86,8 +86,8 @@ class IdGenerator(object):
     """
     ID generator for WAMP request IDs.
 
-    WAMP request IDs are sequential per WAMP session, starting at 0 and
-    wrapping around at 2**53 (both value are inclusive [0, 2**53]).
+    WAMP request IDs are sequential per WAMP session, starting at 1 and
+    wrapping around at 2**53 (both value are inclusive [1, 2**53]).
 
     The upper bound **2**53** is chosen since it is the maximum integer that can be
     represented as a IEEE double such that all smaller integers are representable as well.
@@ -99,7 +99,7 @@ class IdGenerator(object):
     """
 
     def __init__(self):
-        self._next = -1
+        self._next = 0  # starts at 1; next() pre-increments
 
     def next(self):
         """
@@ -110,7 +110,7 @@ class IdGenerator(object):
         """
         self._next += 1
         if self._next > 9007199254740992:
-            self._next = 0
+            self._next = 1
         return self._next
 
     # generator protocol

--- a/autobahn/wamp/message.py
+++ b/autobahn/wamp/message.py
@@ -141,7 +141,7 @@ def check_or_raise_id(value, message=u"WAMP message invalid"):
     """
     if type(value) not in six.integer_types:
         raise ProtocolError(u"{0}: invalid type {1} for ID".format(message, type(value)))
-    if value < 0 or value > 9007199254740992:  # 2**53
+    if value <= 0 or value > 9007199254740992:  # 2**53
         raise ProtocolError(u"{0}: invalid value {1} for ID".format(message, value))
     return value
 

--- a/autobahn/wamp/test/test_protocol.py
+++ b/autobahn/wamp/test/test_protocol.py
@@ -563,9 +563,9 @@ if os.environ.get('USE_TWISTED', False):
             # (the register) and then increment for the call()
             def verify_seq_id(orig, msg):
                 if isinstance(msg, message.Register):
-                    self.assertEqual(msg.request, 0)
-                elif isinstance(msg, message.Call):
                     self.assertEqual(msg.request, 1)
+                elif isinstance(msg, message.Call):
+                    self.assertEqual(msg.request, 2)
                 return orig(msg)
             orig0 = trans0.send
             orig1 = trans1.send


### PR DESCRIPTION
Change documentation and implementation to use 1 as the
starting point, and a unit-test for wraparound. See also #541 