### PR TITLE
Fix onDisconnect invocation to match interface

### DIFF
--- a/autobahn/wamp/protocol.py
+++ b/autobahn/wamp/protocol.py
@@ -749,7 +749,7 @@ class ApplicationSession(BaseSession):
 
             self._session_id = None
 
-        d = txaio.as_future(self.onDisconnect, wasClean)
+        d = txaio.as_future(self.onDisconnect)
 
         def _error(e):
             return self._swallow_error(e, "While firing onDisconnect")
@@ -799,11 +799,11 @@ class ApplicationSession(BaseSession):
         else:
             raise SessionNotReady(u"Already requested to close the session")
 
-    def onDisconnect(self, wasClean):
+    def onDisconnect(self):
         """
         Implements :func:`autobahn.wamp.interfaces.ISession.onDisconnect`
         """
-        return self.fire('disconnect', self, wasClean)
+        return self.fire('disconnect', self, True)
 
     def publish(self, topic, *args, **kwargs):
         """

--- a/autobahn/wamp/test/test_protocol.py
+++ b/autobahn/wamp/test/test_protocol.py
@@ -521,6 +521,28 @@ if os.environ.get('USE_TWISTED', False):
             registration = yield handler.register(on_call, u'com.myapp.procedure1')
             yield registration.unregister()
 
+        def test_on_disconnect_error(self):
+            errors = []
+            class AppSess(ApplicationSession):
+                def onUserError(self, e, msg):
+                    errors.append((e.value, msg))
+
+                def onDisconnect(self, foo, bar, quux='snark'):
+                    # this over-ridden onDisconnect takes the wrong args
+                    raise RuntimeError("This shouldn't happen")
+
+            s = AppSess()
+            MockTransport(s)
+
+            # when the transport closes, it calls onClose which should
+            # dispatch onDisconnect
+            s.onClose(False)
+
+            # ...but we should collect an error, because our
+            # onDisconnect takes the wrong arguments.
+            self.assertEqual(len(errors), 1)
+            self.assertTrue(isinstance(errors[0][0], TypeError))
+
         @inlineCallbacks
         def test_invoke(self):
             handler = ApplicationSession()

--- a/autobahn/wamp/test/test_protocol.py
+++ b/autobahn/wamp/test/test_protocol.py
@@ -523,6 +523,7 @@ if os.environ.get('USE_TWISTED', False):
 
         def test_on_disconnect_error(self):
             errors = []
+
             class AppSess(ApplicationSession):
                 def onUserError(self, e, msg):
                     errors.append((e.value, msg))


### PR DESCRIPTION
It seems that one of the new-API commits on master changed the invocation of ``onDisconnect``, but this doesn't match the interface and so anything that overrides ``ApplicationSession`` may hit this (e.g. many examples break).

Also, include a unit-test I wrote to ensure we're logging errors properly if an onDisconnect has an unexpected signature