### PR TITLE
WAMP - Twisted: Support proxy configuration in ApplicationRunner

### DIFF
--- a/autobahn/twisted/test/test_application_runner.py
+++ b/autobahn/twisted/test/test_application_runner.py
@@ -96,8 +96,12 @@ class TestApplicationRunner(unittest.TestCase):
     def test_runner_bad_proxy(self, fakereactor):
         proxy = u'myproxy'
 
-        with self.assertRaises(AssertionError):
-            ApplicationRunner(u'ws://fake:1234/ws', u'dummy realm', proxy=proxy)
+        self.assertRaises(
+            AssertionError,
+            ApplicationRunner,
+            u'ws://fake:1234/ws', u'dummy realm',
+            proxy=proxy
+        )
 
     @patch('twisted.internet.reactor')
     def test_runner_proxy(self, fakereactor):

--- a/autobahn/twisted/wamp.py
+++ b/autobahn/twisted/wamp.py
@@ -93,7 +93,7 @@ class ApplicationRunner(object):
 
     def __init__(self, url, realm, extra=None, serializers=None,
                  debug=False, debug_wamp=False, debug_app=False,
-                 ssl=None):
+                 ssl=None, proxy=None):
         """
 
         :param url: The WebSocket URL of the WAMP router to connect to (e.g. `ws://somehost.com:8090/somepath`)
@@ -126,10 +126,14 @@ class ApplicationRunner(object):
             :meth:`twisted.internet.ssl.platformTrust` which tries to use
             your distribution's CA certificates.
         :type ssl: :class:`twisted.internet.ssl.CertificateOptions`
+
+        :param proxy: Explicit proxy server to use; a dict with ``host`` and ``port`` keys
+        :type proxy: dict or None
         """
         assert(type(url) == six.text_type)
         assert(type(realm) == six.text_type)
         assert(extra is None or type(extra) == dict)
+        assert(proxy is None or type(proxy) == dict)
         self.url = url
         self.realm = realm
         self.extra = extra or dict()
@@ -138,6 +142,7 @@ class ApplicationRunner(object):
         self.debug_wamp = debug_wamp
         self.debug_app = debug_app
         self.ssl = ssl
+        self.proxy = proxy
 
     def run(self, make, start_reactor=True):
         """
@@ -190,7 +195,7 @@ class ApplicationRunner(object):
 
         # create a WAMP-over-WebSocket transport client factory
         transport_factory = WampWebSocketClientFactory(create, url=self.url, serializers=self.serializers,
-                                                       debug=self.debug, debug_wamp=self.debug_wamp)
+                                                       proxy=self.proxy, debug=self.debug, debug_wamp=self.debug_wamp)
 
         # if user passed ssl= but isn't using isSecure, we'll never
         # use the ssl argument which makes no sense.
@@ -206,7 +211,10 @@ class ApplicationRunner(object):
             from twisted.internet.ssl import optionsForClientTLS
             context_factory = optionsForClientTLS(host)
 
-        if isSecure:
+        if self.proxy is not None:
+            from twisted.internet.endpoints import TCP4ClientEndpoint
+            client = TCP4ClientEndpoint(reactor, self.proxy['host'], self.proxy['port'])
+        elif isSecure:
             from twisted.internet.endpoints import SSL4ClientEndpoint
             assert context_factory is not None
             client = SSL4ClientEndpoint(reactor, host, port, context_factory)

--- a/autobahn/twisted/wamp.py
+++ b/autobahn/twisted/wamp.py
@@ -214,6 +214,7 @@ class ApplicationRunner(object):
         if self.proxy is not None:
             from twisted.internet.endpoints import TCP4ClientEndpoint
             client = TCP4ClientEndpoint(reactor, self.proxy['host'], self.proxy['port'])
+            transport_factory.contextFactory = context_factory
         elif isSecure:
             from twisted.internet.endpoints import SSL4ClientEndpoint
             assert context_factory is not None


### PR DESCRIPTION
Tested with `Squid 3.3.8` and `wss` endpoint.
Warning: by default Squid deny `CONNECT` on !SSL_ports.