### PR TITLE
work around deprecated twisted class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,26 +8,26 @@ env:
   - TOX_ENV=flake8
   - TOX_ENV=py27-tw121
   - TOX_ENV=py27-tw132
-  - TOX_ENV=py27-tw154
+  - TOX_ENV=py27-tw155
   - TOX_ENV=py27-twtrunk
   - TOX_ENV=py27-asyncio
-  - TOX_ENV=py34-tw154
+  - TOX_ENV=py34-tw155
   - TOX_ENV=py34-twtrunk
   - TOX_ENV=py34-asyncio
-  - TOX_ENV=pypy-tw121 
+  - TOX_ENV=pypy-tw121
   - TOX_ENV=pypy-tw132
-  - TOX_ENV=pypy-tw154
+  - TOX_ENV=pypy-tw155
   - TOX_ENV=pypy-twtrunk
   - TOX_ENV=pypy-asyncio
   - TOX_ENV=py26-tw121
   - TOX_ENV=py26-tw132
   - TOX_ENV=py26-tw154
   - TOX_ENV=py26-asyncio
-  - TOX_ENV=py33-tw154
+  - TOX_ENV=py33-tw155
   - TOX_ENV=py33-twtrunk
   - TOX_ENV=py33-asyncio
-# Travis still lacks CPy 3.5 currently (09/25/15)  
-#  - TOX_ENV=py35-tw154
+# Travis still lacks CPy 3.5 currently (09/25/15)
+#  - TOX_ENV=py35-tw155
 #  - TOX_ENV=py35-twtrunk
 #  - TOX_ENV=py35-asyncio
 

--- a/autobahn/twisted/test/test_endpoint_plugins.py
+++ b/autobahn/twisted/test/test_endpoint_plugins.py
@@ -1,0 +1,47 @@
+###############################################################################
+#
+# The MIT License (MIT)
+#
+# Copyright (c) Tavendo GmbH
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+###############################################################################
+
+from __future__ import absolute_import
+
+from twisted.trial.unittest import TestCase
+
+
+class PluginTests(TestCase):
+    def test_import(self):
+        from twisted.plugins import autobahn_endpoints
+        self.assertTrue(hasattr(autobahn_endpoints, 'AutobahnClientParser'))
+
+    def test_parse_client_basic(self):
+        from twisted.plugins import autobahn_endpoints
+        from twisted.internet.endpoints import clientFromString, quoteStringArgument
+        from twisted.internet import reactor
+
+        ep_string = "autobahn:{0}:url={1}".format(
+            quoteStringArgument('tcp:localhost:9000'),
+            quoteStringArgument('ws://localhost:9000'),
+        )
+        # we're just testing that this doesn't fail entirely
+        clientFromString(reactor, ep_string)

--- a/autobahn/twisted/test/test_endpoint_plugins.py
+++ b/autobahn/twisted/test/test_endpoint_plugins.py
@@ -36,6 +36,7 @@ class PluginTests(TestCase):
 
     def test_parse_client_basic(self):
         from twisted.plugins import autobahn_endpoints
+        self.assertTrue(hasattr(autobahn_endpoints, 'AutobahnClientParser'))
         from twisted.internet.endpoints import clientFromString, quoteStringArgument
         from twisted.internet import reactor
 

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ deps =
     tw154: twisted==15.4.0
     tw155: twisted==15.5.0
     twtrunk: https://github.com/twisted/twisted/archive/trunk.zip
-    {tw121,tw132,tw155,twtrunk}: pytest-twisted
+    {tw121,tw132,tw154,tw155,twtrunk}: pytest-twisted
 
     ; asyncio dependencies
     py26-asyncio: trollius>=2.0

--- a/tox.ini
+++ b/tox.ini
@@ -2,11 +2,11 @@
 envlist =
     flake8
     py26-{tw121,tw132,tw154,asyncio}
-    py27-{tw121,tw132,tw154,twtrunk,asyncio}
-    pypy-{tw121,tw132,tw154,twtrunk,asyncio}
-    py33-{tw154,twtrunk,asyncio}
-    py34-{tw154,twtrunk,asyncio}
-    py35-{tw154,twtrunk,asyncio}
+    py27-{tw121,tw132,tw155,twtrunk,asyncio}
+    pypy-{tw121,tw132,tw155,twtrunk,asyncio}
+    py33-{tw155,twtrunk,asyncio}
+    py34-{tw155,twtrunk,asyncio}
+    py35-{tw155,twtrunk,asyncio}
 
 
 [flake8]
@@ -25,8 +25,9 @@ deps =
     tw121: twisted==12.1.0
     tw132: twisted==13.2.0
     tw154: twisted==15.4.0
+    tw155: twisted==15.5.0
     twtrunk: https://github.com/twisted/twisted/archive/trunk.zip
-    {tw121,tw132,tw154,twtrunk}: pytest-twisted
+    {tw121,tw132,tw155,twtrunk}: pytest-twisted
 
     ; asyncio dependencies
     py26-asyncio: trollius>=2.0
@@ -41,14 +42,14 @@ commands =
     python -V
     coverage --version
     asyncio: coverage run {envbindir}/py.test autobahn/
-    tw121,tw132,tw154,twtrunk: coverage run {envbindir}/trial autobahn
+    tw121,tw132,tw155,twtrunk: coverage run {envbindir}/trial autobahn
     coverage report
 
 whitelist_externals = sh
 
 setenv =
    asyncio: USE_ASYNCIO = 1
-   tw121,tw132,tw154,twtrunk: USE_TWISTED = 1
+   tw121,tw132,tw155,twtrunk: USE_TWISTED = 1
 
 
 [testenv:flake8]


### PR DESCRIPTION
In twisted 15.5.0 IStreamClientEndpointStringParserWithReactor replaces IStreamClientEndpointStringParser but since we still support Twisted versions less than 14 we need to do some hackery to support both.

This fixes  #564