### PR TITLE
ConnectionDeny: improved Python 3 support.

### DIFF
--- a/autobahn/twisted/websocket.py
+++ b/autobahn/twisted/websocket.py
@@ -296,7 +296,7 @@ class WrappingWebSocketAdapter(object):
                 if p in self.factory._subprotocols:
                     self._binaryMode = (p != 'base64')
                     return p
-            raise ConnectionDeny(ConnectionDeny.NOT_ACCEPTABLE, "this server only speaks %s WebSocket subprotocols" % self.factory._subprotocols)
+            raise ConnectionDeny(ConnectionDeny.NOT_ACCEPTABLE, u"this server only speaks %s WebSocket subprotocols" % self.factory._subprotocols)
         elif isinstance(requestOrResponse, ConnectionResponse):
             response = requestOrResponse
             if response.protocol not in self.factory._subprotocols:

--- a/autobahn/wamp/websocket.py
+++ b/autobahn/wamp/websocket.py
@@ -183,7 +183,7 @@ class WampWebSocketServerProtocol(WampWebSocketProtocol):
                 return subprotocol, headers
 
         if self.STRICT_PROTOCOL_NEGOTIATION:
-            raise ConnectionDeny(ConnectionDeny.BAD_REQUEST, "This server only speaks WebSocket subprotocols %s" % ', '.join(self.factory.protocols))
+            raise ConnectionDeny(ConnectionDeny.BAD_REQUEST, u"This server only speaks WebSocket subprotocols %s" % ', '.join(self.factory.protocols))
         else:
             # assume wamp.2.json
             self._serializer = self.factory._serializers['json']

--- a/autobahn/websocket/test/test_types.py
+++ b/autobahn/websocket/test/test_types.py
@@ -1,0 +1,74 @@
+import unittest2 as unittest
+from autobahn.websocket.types import ConnectionAccept, ConnectionDeny
+
+
+class ConnectionAcceptTests(unittest.TestCase):
+    """
+    Tests for autobahn.websocket.types.ConnectionAccept.
+    """
+
+    def test_subprotocol_type_assertions(self):
+        """
+        subprotocol must be a unicode string.
+        """
+        with self.assertRaises(AssertionError):
+            ConnectionAccept(subprotocol=b'non-unicode types are invalid')
+
+        unicode_subprotocol = u'unicode is valid'
+        accepted_conn = ConnectionAccept(subprotocol=unicode_subprotocol)
+        self.assertEqual(accepted_conn.subprotocol, unicode_subprotocol)
+
+    def test_headers_type_assertions(self):
+        """
+        headers must be a dictionary with unicode keys, and values that are
+        unicode, lists, or tuples.
+        """
+        with self.assertRaises(AssertionError):
+            ConnectionAccept(headers='non-dictionary types are invalid')
+
+        invalid_keys_dict = {b'this key is invalid': u'this value is valid'}
+        invalid_values_dict = {u'this key is valid': b'this value is invalid'}
+
+        with self.assertRaises(AssertionError):
+            ConnectionAccept(headers=invalid_keys_dict)
+
+        with self.assertRaises(AssertionError):
+            ConnectionAccept(headers=invalid_values_dict)
+
+        valid_dicts = [{u'valid key': u'unicode is valid'},
+                       {u'valid key': []},  # lists are valid
+                       {u'valid key': ()}]  # tuples are valid
+        for valid_dict in valid_dicts:
+            accepted_conn = ConnectionAccept(headers=valid_dict)
+            self.assertEqual(accepted_conn.headers, valid_dict)
+
+
+class ConnectionDenyTests(unittest.TestCase):
+    """
+    Tests for autobahn.websocket.types.ConnectionDeny.x
+    """
+
+    VALID_CODE = 123
+
+    def test_code_type_assertions(self):
+        """
+        code must be an int.
+        """
+        with self.assertRaises(AssertionError):
+            ConnectionDeny(code='invalid code')
+
+        denied_connection = ConnectionDeny(self.VALID_CODE)
+        self.assertEqual(denied_connection.code, self.VALID_CODE)
+
+    def test_reason_type_assertions(self):
+        """
+        reason must be a unicode string.
+        """
+
+        with self.assertRaises(AssertionError):
+            ConnectionDeny(code=self.VALID_CODE, reason=b'invalid reason')
+
+        valid_reason = u'valid reason'
+        denied_connection = ConnectionDeny(self.VALID_CODE,
+                                           reason=valid_reason)
+        self.assertEqual(denied_connection.reason, valid_reason)

--- a/autobahn/websocket/types.py
+++ b/autobahn/websocket/types.py
@@ -180,8 +180,8 @@ class ConnectionAccept(object):
         assert(headers is None or type(headers) == dict)
         if headers is not None:
             for k, v in headers.items():
-                assert(type(k) == unicode)
-                assert(type(v) == unicode or type(v) == list or type(v) == tuple)
+                assert(type(k) == six.text_type)
+                assert(type(v) == six.text_type or type(v) == list or type(v) == tuple)
         self.subprotocol = subprotocol
         self.headers = headers
 
@@ -242,7 +242,7 @@ class ConnectionDeny(Exception):
         :type reason: unicode
         """
         assert(type(code) == int)
-        assert(reason is None or type(reason) == unicode)
+        assert(reason is None or type(reason) == six.text_type)
         self.code = code
         self.reason = reason
 


### PR DESCRIPTION
Using Autobahn's Twisted server protocols on Python 3 can result in unreadable error messages when an incoming connection is denied.  That's because `ConnectionDeny` asserts that it's reason is of type `unicode`, which doesn't exist on Python 3.

A solution is to a) change the assertion to check against `six.text_type` and b) ensure that all relevant call points provide a unicode string.

This pull request does just that, and also fixes a similar issue in `ConnectionAccept.`

Fuzz testing passed and unittest2 passed for Python 2 but I'm unclear how best to write a test for Python 3, as it appears the unit tests for Python 3 require asyncio.