### PR TITLE
Strengthed uri Pattern tests and fixed parsing edge case

### DIFF
--- a/autobahn/wamp/test/test_uri_pattern.py
+++ b/autobahn/wamp/test/test_uri_pattern.py
@@ -48,6 +48,7 @@ class TestUris(unittest.TestCase):
         for u in [u"com.myapp.proc1",
                   u"123",
                   u"com.myapp.<product:int>.update",
+                  u"com.myapp.<category:string>.<subcategory>.list"
                   ]:
             p = Pattern(u, Pattern.URI_TARGET_ENDPOINT)
             self.assertIsInstance(p, Pattern)
@@ -66,6 +67,19 @@ class TestUris(unittest.TestCase):
                 (u"com.myapp.box.update", {u'product': u'box'}),
                 (u"com.myapp.123456.update", {u'product': u'123456'}),
                 (u"com.myapp..update", None),
+            ]
+            ),
+            (u"com.myapp.<product>.update", [
+                (u"com.myapp.0.update", {u'product': u'0'}),
+                (u"com.myapp.abc.update", {u'product': u'abc'}),
+                (u"com.myapp..update", None),
+            ]
+            ),
+            (u"com.myapp.<category:string>.<subcategory:string>.list", [
+                (u"com.myapp.cosmetic.shampoo.list", {u'category': u'cosmetic', u'subcategory': u'shampoo'}),
+                (u"com.myapp...list", None),
+                (u"com.myapp.cosmetic..list", None),
+                (u"com.myapp..shampoo.list", None),
             ]
             )
         ]

--- a/autobahn/wamp/uri.py
+++ b/autobahn/wamp/uri.py
@@ -132,7 +132,7 @@ class Pattern(object):
                     raise Exception("invalid URI")
 
                 nc[name] = str
-                pl.append("(?P<{0}>[a-z][a-z0-9_]*)".format(name))
+                pl.append("(?P<{0}>[a-z0-9_]+)".format(name))
                 continue
 
             match = Pattern._URI_COMPONENT.match(component)


### PR DESCRIPTION
Why can named components without type not start with a number? The old regex implicated that this was done with intention? However IMO this is totally unintuitive (I wouldn't be doing this PR if it were). Some feedback what the original thougth process was behind this would be highly appreciated.