### PR TITLE
Observable API and listeners fixups

### DIFF
--- a/autobahn/wamp/protocol.py
+++ b/autobahn/wamp/protocol.py
@@ -72,7 +72,15 @@ class BaseSession(ObservableMixin):
         """
 
         """
-        ObservableMixin.__init__(self)
+        self.set_valid_events(
+            valid_events=[
+                'join',         # right before onJoin runs
+                'leave',        # after onLeave has run
+                'ready',        # after onJoin and all 'join' listeners have completed
+                'connect',      # right before onConnect
+                'disconnect',   # right after onDisconnect
+            ]
+        )
 
         # this is for library level debugging
         self.debug = False


### PR DESCRIPTION
This makes the ``ObservableMixin`` less fragile for use as a mix-in by eliminating its parameter-taking ``__init__`` method, and some cleanups and docstrings. It also adds an (optional!) list of "valid events" to make users of ``.on()`` (or even internal uses of ``.fire()``) complain if you mis-type an event name.

The other commit tackles the LTS listener API by fixing how they're fired/invoked. Doing the invokes in e.g. ``onJoin`` won't work with most of the code out there (including all the examples) because the API contract never specified to call ``super()`` (and basically no code does this). This means that the 'join' event is basically never fired properly.

So, as per LTS API discussions there are 5 events. Note that I made one subtle change that makes a big difference (to when 'join' fires):

 - join: right before we call onJoin
 - leave: right *after* we call onLeave
 - ready: after all 'join' listeners have completed, and after onJoin has completed
 - connect: right before onConnect
 - disconnect: right after onDisconnect

Above "completed" means the method has run, and any future/deferred returned has also completed. The reason I made 'join' fire *before* onJoin has run and completed is, consider code like:

```
class Foo(ApplicationSession):
    def onJoin(self, details):
        yield self.call(...)
        # etc
        yield self.leave()
```

That is, things that use ``onJoin`` as essentially a "main" function -- do all their work, and then disconnect the session. In the above, if we wait for ``onJoin`` to complete before we fire the 'join' listeners, then we very counter-intuitively would fire 'leave' *before* firing 'join'.

So, now 'join' fires as soon as we get the Hello message, and then the previously-discussed 'ready' fires *after* onJoin has completed (and all 'join' listeners have completed). Also, this is implemented such that it doesn't matter which of the over-ridable methods in ApplicationSession you choose to override, and doesn't care if you call ``super()`` or not. Also, any errors from listeners are logged (but ignored).