### PR TITLE
Fix log method in transport serialization error handling.

### DIFF
--- a/autobahn/wamp/websocket.py
+++ b/autobahn/wamp/websocket.py
@@ -108,7 +108,7 @@ class WampWebSocketProtocol(object):
                 self.log.trace("WAMP SEND: message={message}, session={session}, authid={authid}", authid=self._session._authid, session=self._session._session_id, message=msg)
                 payload, isBinary = self._serializer.serialize(msg)
             except Exception as e:
-                self.log.failure("WAMP message serialization error")
+                self.log.error("WAMP message serialization error")
                 # all exceptions raised from above should be serialization errors ..
                 raise SerializationError(u"WAMP message serialization error: {0}".format(e))
             else:


### PR DESCRIPTION
The error handler on dispatch is swallowing exceptions and never raising SerializationError due to "AttributeError: '_TxaioLogWrapper' object has no attribute 'failure'" being fired in the exception handling routine.