### PR TITLE
Return runner's defer in Application.run

### DIFF
--- a/autobahn/twisted/wamp.py
+++ b/autobahn/twisted/wamp.py
@@ -369,7 +369,7 @@ class Application(object):
         :type realm: unicode
         """
         runner = ApplicationRunner(url, realm)
-        runner.run(self.__call__, start_reactor)
+        return runner.run(self.__call__, start_reactor)
 
     def register(self, uri=None):
         """


### PR DESCRIPTION
Hi,

I'm working on a lib to easily integrate autobahn in a synchronous application (see https://github.com/Scille/autobahn_sync)
Given I use crochet, the twisted reactor is already started when I run `Autobahn.Application`, which means I have to handle by myself the connection errors  (see https://github.com/Scille/autobahn_sync/blob/53c7303a06cf53a783fabbc550b334d48d90d05a/autobahn_sync/core.py#L599)
This is fine except `Autobahn.Application.run` doesn't return the ApplicationRunner's defer.
To fix that I had to copy the `Application.run` function inside my app (see https://github.com/Scille/autobahn_sync/blob/master/autobahn_sync/core.py#L59), which feels like adding complexity for nothing...