### PR TITLE
Marshal fixes

### DIFF
--- a/autobahn/wamp/types.py
+++ b/autobahn/wamp/types.py
@@ -362,7 +362,7 @@ class SubscribeOptions(object):
         """
         options = {}
 
-        if self.match:
+        if self.match is not None:
             options[u'match'] = self.match
 
         return options
@@ -559,10 +559,10 @@ class RegisterOptions(object):
         """
         options = {}
 
-        if self.match:
+        if self.match is not None:
             options[u'match'] = self.match
 
-        if self.invoke:
+        if self.invoke is not None:
             options[u'invoke'] = self.invoke
 
         return options
@@ -657,10 +657,10 @@ class CallOptions(object):
         """
         options = {}
 
-        if self.timeout:
+        if self.timeout is not None:
             options[u'timeout'] = self.timeout
 
-        if self.on_progress:
+        if self.on_progress is not None:
             options[u'receive_progress'] = True
 
         return options

--- a/autobahn/wamp/types.py
+++ b/autobahn/wamp/types.py
@@ -496,28 +496,28 @@ class PublishOptions(object):
         """
         options = {}
 
-        if self.acknowledge:
+        if self.acknowledge is not None:
             options[u'acknowledge'] = self.acknowledge
 
-        if self.exclude_me:
+        if self.exclude_me is not None:
             options[u'exclude_me'] = self.exclude_me
 
-        if self.exclude:
+        if self.exclude is not None:
             options[u'exclude'] = self.exclude if type(self.exclude) == list else [self.exclude]
 
-        if self.exclude_authid:
+        if self.exclude_authid is not None:
             options[u'exclude_authid'] = self.exclude_authid if type(self.exclude_authid) == list else self.exclude_authid
 
-        if self.exclude_authrole:
+        if self.exclude_authrole is not None:
             options[u'exclude_authrole'] = self.exclude_authrole if type(self.exclude_authrole) == list else self.exclude_authrole
 
-        if self.eligible:
+        if self.eligible is not None:
             options[u'eligible'] = self.eligible if type(self.eligible) == list else self.eligible
 
-        if self.eligible_authid:
+        if self.eligible_authid is not None:
             options[u'eligible_authid'] = self.eligible_authid if type(self.eligible_authid) == list else self.eligible_authid
 
-        if self.eligible_authrole:
+        if self.eligible_authrole is not None:
             options[u'eligible_authrole'] = self.eligible_authrole if type(self.eligible_authrole) == list else self.eligible_authrole
 
         return options


### PR DESCRIPTION
I discovered this from some "exclude_me=False" test-cases; not sure if they're all strictly necessary but it matches the way the `messages.py` stuff works (and at least when you pass `exclude_me=False` it just doesn't work right now because that never gets serialized across).