### PR TITLE
fix: plural noun to reference unordered list

### DIFF
--- a/doc/websocket/programming.rst
+++ b/doc/websocket/programming.rst
@@ -276,7 +276,7 @@ On the other hand, for a WebSocket client protocol, ``onConnect()`` will fire wi
       def onConnect(self, response):
          print("Connected to Server: {}".format(response.peer))
 
-In this callback you can do thing like
+In this callback you can do things like
 
 * checking or setting cookies or other HTTP headers
 * verifying the client IP address


### PR DESCRIPTION
Small change in `doc/websocket/programming.rst`.

This.

>In this callback you can do things like

>* checking or setting cookies or other HTTP headers
* verifying the client IP address
* checking the origin of the WebSocket request
* negotiate WebSocket subprotocols


in place of this 


>In this callback you can do thing like

>* checking or setting cookies or other HTTP headers
* verifying the client IP address
* checking the origin of the WebSocket request
* negotiate WebSocket subprotocols
