### PR TITLE
Move parseWsUrl and createWsUrl to a new package

### DIFF
--- a/autobahn/asyncio/wamp.py
+++ b/autobahn/asyncio/wamp.py
@@ -31,7 +31,7 @@ import six
 
 from autobahn.wamp import protocol
 from autobahn.wamp.types import ComponentConfig
-from autobahn.websocket.util import parse_ws_url
+from autobahn.websocket.util import parse_url
 from autobahn.asyncio.websocket import WampWebSocketClientFactory
 
 try:
@@ -127,7 +127,7 @@ class ApplicationRunner(object):
             else:
                 return session
 
-        isSecure, host, port, resource, path, params = parse_ws_url(self.url)
+        isSecure, host, port, resource, path, params = parse_url(self.url)
 
         if self.ssl is None:
             ssl = isSecure

--- a/autobahn/asyncio/wamp.py
+++ b/autobahn/asyncio/wamp.py
@@ -31,7 +31,7 @@ import six
 
 from autobahn.wamp import protocol
 from autobahn.wamp.types import ComponentConfig
-from autobahn.websocket.protocol import parseWsUrl
+from autobahn.websocket.util import parse_ws_url
 from autobahn.asyncio.websocket import WampWebSocketClientFactory
 
 try:
@@ -127,7 +127,7 @@ class ApplicationRunner(object):
             else:
                 return session
 
-        isSecure, host, port, resource, path, params = parseWsUrl(self.url)
+        isSecure, host, port, resource, path, params = parse_ws_url(self.url)
 
         if self.ssl is None:
             ssl = isSecure

--- a/autobahn/twisted/wamp.py
+++ b/autobahn/twisted/wamp.py
@@ -34,7 +34,7 @@ from twisted.internet.defer import inlineCallbacks
 
 from autobahn.wamp import protocol
 from autobahn.wamp.types import ComponentConfig
-from autobahn.websocket.protocol import parseWsUrl
+from autobahn.websocket.util import parse_ws_url
 from autobahn.twisted.websocket import WampWebSocketClientFactory
 
 # new API
@@ -159,7 +159,7 @@ class ApplicationRunner(object):
             txaio.config.loop = reactor
             txaio.start_logging(level='info')
 
-        isSecure, host, port, resource, path, params = parseWsUrl(self.url)
+        isSecure, host, port, resource, path, params = parse_ws_url(self.url)
 
         # factory for use ApplicationSession
         def create():
@@ -574,7 +574,7 @@ if service:
             """
             Setup the application component.
             """
-            is_secure, host, port, resource, path, params = parseWsUrl(self.url)
+            is_secure, host, port, resource, path, params = parse_ws_url(self.url)
 
             # factory for use ApplicationSession
             def create():

--- a/autobahn/twisted/wamp.py
+++ b/autobahn/twisted/wamp.py
@@ -34,7 +34,7 @@ from twisted.internet.defer import inlineCallbacks
 
 from autobahn.wamp import protocol
 from autobahn.wamp.types import ComponentConfig
-from autobahn.websocket.util import parse_ws_url
+from autobahn.websocket.util import parse_url
 from autobahn.twisted.websocket import WampWebSocketClientFactory
 
 # new API
@@ -159,7 +159,7 @@ class ApplicationRunner(object):
             txaio.config.loop = reactor
             txaio.start_logging(level='info')
 
-        isSecure, host, port, resource, path, params = parse_ws_url(self.url)
+        isSecure, host, port, resource, path, params = parse_url(self.url)
 
         # factory for use ApplicationSession
         def create():
@@ -574,7 +574,7 @@ if service:
             """
             Setup the application component.
             """
-            is_secure, host, port, resource, path, params = parse_ws_url(self.url)
+            is_secure, host, port, resource, path, params = parse_url(self.url)
 
             # factory for use ApplicationSession
             def create():

--- a/autobahn/wamp/component.py
+++ b/autobahn/wamp/component.py
@@ -33,7 +33,7 @@ import six
 import txaio
 
 from autobahn.util import ObservableMixin
-from autobahn.websocket.util import parse_ws_url
+from autobahn.websocket.util import parse_url
 from autobahn.wamp.types import ComponentConfig
 
 __all__ = ('Connection')
@@ -190,7 +190,7 @@ class Component(ObservableMixin):
         # allows to provide an URL instead of a list of transports
         if type(transports) == six.text_type:
             url = transports
-            is_secure, host, port, resource, path, params = parse_ws_url(url)
+            is_secure, host, port, resource, path, params = parse_url(url)
             transport = {
                 'type': 'websocket',
                 'url': url,

--- a/autobahn/wamp/component.py
+++ b/autobahn/wamp/component.py
@@ -33,7 +33,7 @@ import six
 import txaio
 
 from autobahn.util import ObservableMixin
-from autobahn.websocket.protocol import parseWsUrl
+from autobahn.websocket.util import parse_ws_url
 from autobahn.wamp.types import ComponentConfig
 
 __all__ = ('Connection')
@@ -190,7 +190,7 @@ class Component(ObservableMixin):
         # allows to provide an URL instead of a list of transports
         if type(transports) == six.text_type:
             url = transports
-            is_secure, host, port, resource, path, params = parseWsUrl(url)
+            is_secure, host, port, resource, path, params = parse_ws_url(url)
             transport = {
                 'type': 'websocket',
                 'url': url,

--- a/autobahn/websocket/protocol.py
+++ b/autobahn/websocket/protocol.py
@@ -52,6 +52,7 @@ from autobahn.util import Stopwatch, newid, wildcards2patterns, encode_truncate
 from autobahn.websocket.utf8validator import Utf8Validator
 from autobahn.websocket.xormasker import XorMaskerNull, createXorMasker
 from autobahn.websocket.compress import PERMESSAGE_COMPRESSION_EXTENSION
+from autobahn.websocket.util import parseWsUrl, createWsUrl
 
 from six.moves import urllib
 import txaio
@@ -61,31 +62,7 @@ if six.PY3:
     # noinspection PyShadowingBuiltins
     xrange = range
 
-# The Python urlparse module currently does not contain the ws/wss
-# schemes, so we add those dynamically (which is a hack of course).
-# Since the urllib from six.moves does not seem to expose the stuff
-# we monkey patch here, we do it manually.
-#
-# Important: if you change this stuff (you shouldn't), make sure
-# _all_ our unit tests for WS URLs succeed
-#
-if not six.PY3:
-    # Python 2
-    import urlparse
-else:
-    # Python 3
-    from urllib import parse as urlparse
-
-wsschemes = ["ws", "wss"]
-urlparse.uses_relative.extend(wsschemes)
-urlparse.uses_netloc.extend(wsschemes)
-urlparse.uses_params.extend(wsschemes)
-urlparse.uses_query.extend(wsschemes)
-urlparse.uses_fragment.extend(wsschemes)
-
-__all__ = ("createWsUrl",
-           "parseWsUrl",
-           "ConnectionRequest",
+__all__ = ("ConnectionRequest",
            "ConnectionResponse",
            "Timings",
            "WebSocketProtocol",
@@ -94,90 +71,6 @@ __all__ = ("createWsUrl",
            "WebSocketServerFactory",
            "WebSocketClientProtocol",
            "WebSocketClientFactory")
-
-
-def createWsUrl(hostname, port=None, isSecure=False, path=None, params=None):
-    """
-    Create a WebSocket URL from components.
-
-    :param hostname: WebSocket server hostname.
-    :type hostname: str
-    :param port: WebSocket service port or None (to select default ports 80/443 depending on isSecure).
-    :type port: int
-    :param isSecure: Set True for secure WebSocket ("wss" scheme).
-    :type isSecure: bool
-    :param path: Path component of addressed resource (will be properly URL escaped).
-    :type path: str
-    :param params: A dictionary of key-values to construct the query component of the addressed resource (will be properly URL escaped).
-    :type params: dict
-
-    :returns: str -- Constructed WebSocket URL.
-    """
-    if port is not None:
-        netloc = "%s:%d" % (hostname, port)
-    else:
-        if isSecure:
-            netloc = "%s:443" % hostname
-        else:
-            netloc = "%s:80" % hostname
-    if isSecure:
-        scheme = "wss"
-    else:
-        scheme = "ws"
-    if path is not None:
-        ppath = urllib.parse.quote(path)
-    else:
-        ppath = "/"
-    if params is not None:
-        query = urllib.parse.urlencode(params)
-    else:
-        query = None
-    return urllib.parse.urlunparse((scheme, netloc, ppath, None, query, None))
-
-
-def parseWsUrl(url):
-    """
-    Parses as WebSocket URL into it's components and returns a tuple (isSecure, host, port, resource, path, params).
-
-    isSecure is a flag which is True for wss URLs.
-    host is the hostname or IP from the URL.
-    port is the port from the URL or standard port derived from scheme (ws = 80, wss = 443).
-    resource is the /resource name/ from the URL, the /path/ together with the (optional) /query/ component.
-    path is the /path/ component properly unescaped.
-    params is the /query) component properly unescaped and returned as dictionary.
-
-    :param url: A valid WebSocket URL, i.e. `ws://localhost:9000/myresource?param1=23&param2=666`
-    :type url: str
-
-    :returns: tuple -- A tuple (isSecure, host, port, resource, path, params)
-    """
-    parsed = urlparse.urlparse(url)
-    if not parsed.hostname or parsed.hostname == "":
-        raise Exception("invalid WebSocket URL: missing hostname")
-    if parsed.scheme not in ["ws", "wss"]:
-        raise Exception("invalid WebSocket URL: bogus protocol scheme '%s'" % parsed.scheme)
-    if parsed.port is None or parsed.port == "":
-        if parsed.scheme == "ws":
-            port = 80
-        else:
-            port = 443
-    else:
-        port = int(parsed.port)
-    if parsed.fragment is not None and parsed.fragment != "":
-        raise Exception("invalid WebSocket URL: non-empty fragment '%s" % parsed.fragment)
-    if parsed.path is not None and parsed.path != "":
-        ppath = parsed.path
-        path = urllib.parse.unquote(ppath)
-    else:
-        ppath = "/"
-        path = ppath
-    if parsed.query is not None and parsed.query != "":
-        resource = ppath + "?" + parsed.query
-        params = urlparse.parse_qs(parsed.query)
-    else:
-        resource = ppath
-        params = {}
-    return parsed.scheme == "wss", parsed.hostname, port, resource, path, params
 
 
 class TrafficStats(object):

--- a/autobahn/websocket/protocol.py
+++ b/autobahn/websocket/protocol.py
@@ -52,7 +52,7 @@ from autobahn.util import Stopwatch, newid, wildcards2patterns, encode_truncate
 from autobahn.websocket.utf8validator import Utf8Validator
 from autobahn.websocket.xormasker import XorMaskerNull, createXorMasker
 from autobahn.websocket.compress import PERMESSAGE_COMPRESSION_EXTENSION
-from autobahn.websocket.util import parse_ws_url
+from autobahn.websocket.util import parse_url
 
 from six.moves import urllib
 import txaio
@@ -2929,7 +2929,7 @@ class WebSocketServerFactory(WebSocketFactory):
         :type externalPort: int
         """
         # parse WebSocket URI into components
-        (isSecure, host, port, resource, path, params) = parse_ws_url(url or "ws://localhost")
+        (isSecure, host, port, resource, path, params) = parse_url(url or "ws://localhost")
         if len(params) > 0:
             raise Exception("query parameters specified for server WebSocket URL")
         self.url = url
@@ -3656,7 +3656,7 @@ class WebSocketClientFactory(WebSocketFactory):
         :type proxy: dict or None
         """
         # parse WebSocket URI into components
-        (isSecure, host, port, resource, path, params) = parse_ws_url(url or "ws://localhost")
+        (isSecure, host, port, resource, path, params) = parse_url(url or "ws://localhost")
         self.url = url
         self.isSecure = isSecure
         self.host = host

--- a/autobahn/websocket/protocol.py
+++ b/autobahn/websocket/protocol.py
@@ -52,7 +52,7 @@ from autobahn.util import Stopwatch, newid, wildcards2patterns, encode_truncate
 from autobahn.websocket.utf8validator import Utf8Validator
 from autobahn.websocket.xormasker import XorMaskerNull, createXorMasker
 from autobahn.websocket.compress import PERMESSAGE_COMPRESSION_EXTENSION
-from autobahn.websocket.util import parseWsUrl, createWsUrl
+from autobahn.websocket.util import parse_ws_url
 
 from six.moves import urllib
 import txaio
@@ -2929,7 +2929,7 @@ class WebSocketServerFactory(WebSocketFactory):
         :type externalPort: int
         """
         # parse WebSocket URI into components
-        (isSecure, host, port, resource, path, params) = parseWsUrl(url or "ws://localhost")
+        (isSecure, host, port, resource, path, params) = parse_ws_url(url or "ws://localhost")
         if len(params) > 0:
             raise Exception("query parameters specified for server WebSocket URL")
         self.url = url
@@ -3656,7 +3656,7 @@ class WebSocketClientFactory(WebSocketFactory):
         :type proxy: dict or None
         """
         # parse WebSocket URI into components
-        (isSecure, host, port, resource, path, params) = parseWsUrl(url or "ws://localhost")
+        (isSecure, host, port, resource, path, params) = parse_ws_url(url or "ws://localhost")
         self.url = url
         self.isSecure = isSecure
         self.host = host

--- a/autobahn/websocket/test/test_websocket_url.py
+++ b/autobahn/websocket/test/test_websocket_url.py
@@ -28,100 +28,100 @@ from __future__ import absolute_import
 
 import unittest2 as unittest
 
-from autobahn.websocket.util import create_ws_url, parse_ws_url
+from autobahn.websocket.util import create_url, parse_url
 
 
 class TestCreateWsUrl(unittest.TestCase):
 
     def test_create_url01(self):
-        self.assertEqual(create_ws_url("localhost"), "ws://localhost:80/")
+        self.assertEqual(create_url("localhost"), "ws://localhost:80/")
 
     def test_create_url02(self):
-        self.assertEqual(create_ws_url("localhost", port=8090), "ws://localhost:8090/")
+        self.assertEqual(create_url("localhost", port=8090), "ws://localhost:8090/")
 
     def test_create_url03(self):
-        self.assertEqual(create_ws_url("localhost", path="ws"), "ws://localhost:80/ws")
+        self.assertEqual(create_url("localhost", path="ws"), "ws://localhost:80/ws")
 
     def test_create_url04(self):
-        self.assertEqual(create_ws_url("localhost", path="/ws"), "ws://localhost:80/ws")
+        self.assertEqual(create_url("localhost", path="/ws"), "ws://localhost:80/ws")
 
     def test_create_url05(self):
-        self.assertEqual(create_ws_url("localhost", path="/ws/foobar"), "ws://localhost:80/ws/foobar")
+        self.assertEqual(create_url("localhost", path="/ws/foobar"), "ws://localhost:80/ws/foobar")
 
     def test_create_url06(self):
-        self.assertEqual(create_ws_url("localhost", isSecure=True), "wss://localhost:443/")
+        self.assertEqual(create_url("localhost", isSecure=True), "wss://localhost:443/")
 
     def test_create_url07(self):
-        self.assertEqual(create_ws_url("localhost", isSecure=True, port=443), "wss://localhost:443/")
+        self.assertEqual(create_url("localhost", isSecure=True, port=443), "wss://localhost:443/")
 
     def test_create_url08(self):
-        self.assertEqual(create_ws_url("localhost", isSecure=True, port=80), "wss://localhost:80/")
+        self.assertEqual(create_url("localhost", isSecure=True, port=80), "wss://localhost:80/")
 
     def test_create_url09(self):
-        self.assertEqual(create_ws_url("localhost", isSecure=True, port=9090, path="ws", params={'foo': 'bar'}), "wss://localhost:9090/ws?foo=bar")
+        self.assertEqual(create_url("localhost", isSecure=True, port=9090, path="ws", params={'foo': 'bar'}), "wss://localhost:9090/ws?foo=bar")
 
     def test_create_url10(self):
-        wsurl = create_ws_url("localhost", isSecure=True, port=9090, path="ws", params={'foo': 'bar', 'moo': 23})
+        wsurl = create_url("localhost", isSecure=True, port=9090, path="ws", params={'foo': 'bar', 'moo': 23})
         self.assertTrue(wsurl == "wss://localhost:9090/ws?foo=bar&moo=23" or wsurl == "wss://localhost:9090/ws?moo=23&foo=bar")
 
     def test_create_url11(self):
-        self.assertEqual(create_ws_url("127.0.0.1", path="ws"), "ws://127.0.0.1:80/ws")
+        self.assertEqual(create_url("127.0.0.1", path="ws"), "ws://127.0.0.1:80/ws")
 
     def test_create_url12(self):
-        self.assertEqual(create_ws_url("62.146.25.34", path="ws"), "ws://62.146.25.34:80/ws")
+        self.assertEqual(create_url("62.146.25.34", path="ws"), "ws://62.146.25.34:80/ws")
 
     def test_create_url13(self):
-        self.assertEqual(create_ws_url("subsub1.sub1.something.com", path="ws"), "ws://subsub1.sub1.something.com:80/ws")
+        self.assertEqual(create_url("subsub1.sub1.something.com", path="ws"), "ws://subsub1.sub1.something.com:80/ws")
 
     def test_create_url14(self):
-        self.assertEqual(create_ws_url("::1", path="ws"), "ws://::1:80/ws")
+        self.assertEqual(create_url("::1", path="ws"), "ws://::1:80/ws")
 
     def test_create_url15(self):
-        self.assertEqual(create_ws_url("0:0:0:0:0:0:0:1", path="ws"), "ws://0:0:0:0:0:0:0:1:80/ws")
+        self.assertEqual(create_url("0:0:0:0:0:0:0:1", path="ws"), "ws://0:0:0:0:0:0:0:1:80/ws")
 
 
 class TestParseWsUrl(unittest.TestCase):
 
-    # parse_ws_url -> (isSecure, host, port, resource, path, params)
+    # parse_url -> (isSecure, host, port, resource, path, params)
 
     def test_parse_url01(self):
-        self.assertEqual(parse_ws_url("ws://localhost"), (False, 'localhost', 80, '/', '/', {}))
+        self.assertEqual(parse_url("ws://localhost"), (False, 'localhost', 80, '/', '/', {}))
 
     def test_parse_url02(self):
-        self.assertEqual(parse_ws_url("ws://localhost:80"), (False, 'localhost', 80, '/', '/', {}))
+        self.assertEqual(parse_url("ws://localhost:80"), (False, 'localhost', 80, '/', '/', {}))
 
     def test_parse_url03(self):
-        self.assertEqual(parse_ws_url("wss://localhost"), (True, 'localhost', 443, '/', '/', {}))
+        self.assertEqual(parse_url("wss://localhost"), (True, 'localhost', 443, '/', '/', {}))
 
     def test_parse_url04(self):
-        self.assertEqual(parse_ws_url("wss://localhost:443"), (True, 'localhost', 443, '/', '/', {}))
+        self.assertEqual(parse_url("wss://localhost:443"), (True, 'localhost', 443, '/', '/', {}))
 
     def test_parse_url05(self):
-        self.assertEqual(parse_ws_url("wss://localhost/ws"), (True, 'localhost', 443, '/ws', '/ws', {}))
+        self.assertEqual(parse_url("wss://localhost/ws"), (True, 'localhost', 443, '/ws', '/ws', {}))
 
     def test_parse_url06(self):
-        self.assertEqual(parse_ws_url("wss://localhost/ws?foo=bar"), (True, 'localhost', 443, '/ws?foo=bar', '/ws', {'foo': ['bar']}))
+        self.assertEqual(parse_url("wss://localhost/ws?foo=bar"), (True, 'localhost', 443, '/ws?foo=bar', '/ws', {'foo': ['bar']}))
 
     def test_parse_url07(self):
-        self.assertEqual(parse_ws_url("wss://localhost/ws?foo=bar&moo=23"), (True, 'localhost', 443, '/ws?foo=bar&moo=23', '/ws', {'moo': ['23'], 'foo': ['bar']}))
+        self.assertEqual(parse_url("wss://localhost/ws?foo=bar&moo=23"), (True, 'localhost', 443, '/ws?foo=bar&moo=23', '/ws', {'moo': ['23'], 'foo': ['bar']}))
 
     def test_parse_url08(self):
-        self.assertEqual(parse_ws_url("wss://localhost/ws?foo=bar&moo=23&moo=44"), (True, 'localhost', 443, '/ws?foo=bar&moo=23&moo=44', '/ws', {'moo': ['23', '44'], 'foo': ['bar']}))
+        self.assertEqual(parse_url("wss://localhost/ws?foo=bar&moo=23&moo=44"), (True, 'localhost', 443, '/ws?foo=bar&moo=23&moo=44', '/ws', {'moo': ['23', '44'], 'foo': ['bar']}))
 
     def test_parse_url09(self):
-        self.assertRaises(Exception, parse_ws_url, "http://localhost")
+        self.assertRaises(Exception, parse_url, "http://localhost")
 
     def test_parse_url10(self):
-        self.assertRaises(Exception, parse_ws_url, "https://localhost")
+        self.assertRaises(Exception, parse_url, "https://localhost")
 
     def test_parse_url11(self):
-        self.assertRaises(Exception, parse_ws_url, "http://localhost:80")
+        self.assertRaises(Exception, parse_url, "http://localhost:80")
 
     def test_parse_url12(self):
-        self.assertRaises(Exception, parse_ws_url, "http://localhost#frag1")
+        self.assertRaises(Exception, parse_url, "http://localhost#frag1")
 
     def test_parse_url13(self):
-        self.assertRaises(Exception, parse_ws_url, "wss://")
+        self.assertRaises(Exception, parse_url, "wss://")
 
     def test_parse_url14(self):
-        self.assertRaises(Exception, parse_ws_url, "ws://")
+        self.assertRaises(Exception, parse_url, "ws://")

--- a/autobahn/websocket/test/test_websocket_url.py
+++ b/autobahn/websocket/test/test_websocket_url.py
@@ -28,100 +28,100 @@ from __future__ import absolute_import
 
 import unittest2 as unittest
 
-from autobahn.websocket.protocol import createWsUrl, parseWsUrl
+from autobahn.websocket.util import create_ws_url, parse_ws_url
 
 
 class TestCreateWsUrl(unittest.TestCase):
 
     def test_create_url01(self):
-        self.assertEqual(createWsUrl("localhost"), "ws://localhost:80/")
+        self.assertEqual(create_ws_url("localhost"), "ws://localhost:80/")
 
     def test_create_url02(self):
-        self.assertEqual(createWsUrl("localhost", port=8090), "ws://localhost:8090/")
+        self.assertEqual(create_ws_url("localhost", port=8090), "ws://localhost:8090/")
 
     def test_create_url03(self):
-        self.assertEqual(createWsUrl("localhost", path="ws"), "ws://localhost:80/ws")
+        self.assertEqual(create_ws_url("localhost", path="ws"), "ws://localhost:80/ws")
 
     def test_create_url04(self):
-        self.assertEqual(createWsUrl("localhost", path="/ws"), "ws://localhost:80/ws")
+        self.assertEqual(create_ws_url("localhost", path="/ws"), "ws://localhost:80/ws")
 
     def test_create_url05(self):
-        self.assertEqual(createWsUrl("localhost", path="/ws/foobar"), "ws://localhost:80/ws/foobar")
+        self.assertEqual(create_ws_url("localhost", path="/ws/foobar"), "ws://localhost:80/ws/foobar")
 
     def test_create_url06(self):
-        self.assertEqual(createWsUrl("localhost", isSecure=True), "wss://localhost:443/")
+        self.assertEqual(create_ws_url("localhost", isSecure=True), "wss://localhost:443/")
 
     def test_create_url07(self):
-        self.assertEqual(createWsUrl("localhost", isSecure=True, port=443), "wss://localhost:443/")
+        self.assertEqual(create_ws_url("localhost", isSecure=True, port=443), "wss://localhost:443/")
 
     def test_create_url08(self):
-        self.assertEqual(createWsUrl("localhost", isSecure=True, port=80), "wss://localhost:80/")
+        self.assertEqual(create_ws_url("localhost", isSecure=True, port=80), "wss://localhost:80/")
 
     def test_create_url09(self):
-        self.assertEqual(createWsUrl("localhost", isSecure=True, port=9090, path="ws", params={'foo': 'bar'}), "wss://localhost:9090/ws?foo=bar")
+        self.assertEqual(create_ws_url("localhost", isSecure=True, port=9090, path="ws", params={'foo': 'bar'}), "wss://localhost:9090/ws?foo=bar")
 
     def test_create_url10(self):
-        wsurl = createWsUrl("localhost", isSecure=True, port=9090, path="ws", params={'foo': 'bar', 'moo': 23})
+        wsurl = create_ws_url("localhost", isSecure=True, port=9090, path="ws", params={'foo': 'bar', 'moo': 23})
         self.assertTrue(wsurl == "wss://localhost:9090/ws?foo=bar&moo=23" or wsurl == "wss://localhost:9090/ws?moo=23&foo=bar")
 
     def test_create_url11(self):
-        self.assertEqual(createWsUrl("127.0.0.1", path="ws"), "ws://127.0.0.1:80/ws")
+        self.assertEqual(create_ws_url("127.0.0.1", path="ws"), "ws://127.0.0.1:80/ws")
 
     def test_create_url12(self):
-        self.assertEqual(createWsUrl("62.146.25.34", path="ws"), "ws://62.146.25.34:80/ws")
+        self.assertEqual(create_ws_url("62.146.25.34", path="ws"), "ws://62.146.25.34:80/ws")
 
     def test_create_url13(self):
-        self.assertEqual(createWsUrl("subsub1.sub1.something.com", path="ws"), "ws://subsub1.sub1.something.com:80/ws")
+        self.assertEqual(create_ws_url("subsub1.sub1.something.com", path="ws"), "ws://subsub1.sub1.something.com:80/ws")
 
     def test_create_url14(self):
-        self.assertEqual(createWsUrl("::1", path="ws"), "ws://::1:80/ws")
+        self.assertEqual(create_ws_url("::1", path="ws"), "ws://::1:80/ws")
 
     def test_create_url15(self):
-        self.assertEqual(createWsUrl("0:0:0:0:0:0:0:1", path="ws"), "ws://0:0:0:0:0:0:0:1:80/ws")
+        self.assertEqual(create_ws_url("0:0:0:0:0:0:0:1", path="ws"), "ws://0:0:0:0:0:0:0:1:80/ws")
 
 
 class TestParseWsUrl(unittest.TestCase):
 
-    # parseWsUrl -> (isSecure, host, port, resource, path, params)
+    # parse_ws_url -> (isSecure, host, port, resource, path, params)
 
     def test_parse_url01(self):
-        self.assertEqual(parseWsUrl("ws://localhost"), (False, 'localhost', 80, '/', '/', {}))
+        self.assertEqual(parse_ws_url("ws://localhost"), (False, 'localhost', 80, '/', '/', {}))
 
     def test_parse_url02(self):
-        self.assertEqual(parseWsUrl("ws://localhost:80"), (False, 'localhost', 80, '/', '/', {}))
+        self.assertEqual(parse_ws_url("ws://localhost:80"), (False, 'localhost', 80, '/', '/', {}))
 
     def test_parse_url03(self):
-        self.assertEqual(parseWsUrl("wss://localhost"), (True, 'localhost', 443, '/', '/', {}))
+        self.assertEqual(parse_ws_url("wss://localhost"), (True, 'localhost', 443, '/', '/', {}))
 
     def test_parse_url04(self):
-        self.assertEqual(parseWsUrl("wss://localhost:443"), (True, 'localhost', 443, '/', '/', {}))
+        self.assertEqual(parse_ws_url("wss://localhost:443"), (True, 'localhost', 443, '/', '/', {}))
 
     def test_parse_url05(self):
-        self.assertEqual(parseWsUrl("wss://localhost/ws"), (True, 'localhost', 443, '/ws', '/ws', {}))
+        self.assertEqual(parse_ws_url("wss://localhost/ws"), (True, 'localhost', 443, '/ws', '/ws', {}))
 
     def test_parse_url06(self):
-        self.assertEqual(parseWsUrl("wss://localhost/ws?foo=bar"), (True, 'localhost', 443, '/ws?foo=bar', '/ws', {'foo': ['bar']}))
+        self.assertEqual(parse_ws_url("wss://localhost/ws?foo=bar"), (True, 'localhost', 443, '/ws?foo=bar', '/ws', {'foo': ['bar']}))
 
     def test_parse_url07(self):
-        self.assertEqual(parseWsUrl("wss://localhost/ws?foo=bar&moo=23"), (True, 'localhost', 443, '/ws?foo=bar&moo=23', '/ws', {'moo': ['23'], 'foo': ['bar']}))
+        self.assertEqual(parse_ws_url("wss://localhost/ws?foo=bar&moo=23"), (True, 'localhost', 443, '/ws?foo=bar&moo=23', '/ws', {'moo': ['23'], 'foo': ['bar']}))
 
     def test_parse_url08(self):
-        self.assertEqual(parseWsUrl("wss://localhost/ws?foo=bar&moo=23&moo=44"), (True, 'localhost', 443, '/ws?foo=bar&moo=23&moo=44', '/ws', {'moo': ['23', '44'], 'foo': ['bar']}))
+        self.assertEqual(parse_ws_url("wss://localhost/ws?foo=bar&moo=23&moo=44"), (True, 'localhost', 443, '/ws?foo=bar&moo=23&moo=44', '/ws', {'moo': ['23', '44'], 'foo': ['bar']}))
 
     def test_parse_url09(self):
-        self.assertRaises(Exception, parseWsUrl, "http://localhost")
+        self.assertRaises(Exception, parse_ws_url, "http://localhost")
 
     def test_parse_url10(self):
-        self.assertRaises(Exception, parseWsUrl, "https://localhost")
+        self.assertRaises(Exception, parse_ws_url, "https://localhost")
 
     def test_parse_url11(self):
-        self.assertRaises(Exception, parseWsUrl, "http://localhost:80")
+        self.assertRaises(Exception, parse_ws_url, "http://localhost:80")
 
     def test_parse_url12(self):
-        self.assertRaises(Exception, parseWsUrl, "http://localhost#frag1")
+        self.assertRaises(Exception, parse_ws_url, "http://localhost#frag1")
 
     def test_parse_url13(self):
-        self.assertRaises(Exception, parseWsUrl, "wss://")
+        self.assertRaises(Exception, parse_ws_url, "wss://")
 
     def test_parse_url14(self):
-        self.assertRaises(Exception, parseWsUrl, "ws://")
+        self.assertRaises(Exception, parse_ws_url, "ws://")

--- a/autobahn/websocket/util.py
+++ b/autobahn/websocket/util.py
@@ -51,11 +51,11 @@ urlparse.uses_query.extend(wsschemes)
 urlparse.uses_fragment.extend(wsschemes)
 
 __all__ = (
-    "create_ws_url",
-    "parse_ws_url",
+    "create_url",
+    "parse_url",
 )
 
-def create_ws_url(hostname, port=None, isSecure=False, path=None, params=None):
+def create_url(hostname, port=None, isSecure=False, path=None, params=None):
     """
     Create a WebSocket URL from components.
 
@@ -102,7 +102,7 @@ def create_ws_url(hostname, port=None, isSecure=False, path=None, params=None):
     return urllib.parse.urlunparse((scheme, netloc, ppath, None, query, None))
 
 
-def parse_ws_url(url):
+def parse_url(url):
     """
     Parses as WebSocket URL into it's components and returns a tuple (isSecure, host, port, resource, path, params).
 

--- a/autobahn/websocket/util.py
+++ b/autobahn/websocket/util.py
@@ -51,11 +51,11 @@ urlparse.uses_query.extend(wsschemes)
 urlparse.uses_fragment.extend(wsschemes)
 
 __all__ = (
-    "createWsUrl",
-    "parseWsUrl",
+    "create_ws_url",
+    "parse_ws_url",
 )
 
-def createWsUrl(hostname, port=None, isSecure=False, path=None, params=None):
+def create_ws_url(hostname, port=None, isSecure=False, path=None, params=None):
     """
     Create a WebSocket URL from components.
 
@@ -102,7 +102,7 @@ def createWsUrl(hostname, port=None, isSecure=False, path=None, params=None):
     return urllib.parse.urlunparse((scheme, netloc, ppath, None, query, None))
 
 
-def parseWsUrl(url):
+def parse_ws_url(url):
     """
     Parses as WebSocket URL into it's components and returns a tuple (isSecure, host, port, resource, path, params).
 

--- a/autobahn/websocket/util.py
+++ b/autobahn/websocket/util.py
@@ -1,0 +1,150 @@
+###############################################################################
+#
+# The MIT License (MIT)
+#
+# Copyright (c) Tavendo GmbH
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+###############################################################################
+
+from __future__ import absolute_import
+
+import six
+from six.moves import urllib
+# The Python urlparse module currently does not contain the ws/wss
+# schemes, so we add those dynamically (which is a hack of course).
+# Since the urllib from six.moves does not seem to expose the stuff
+# we monkey patch here, we do it manually.
+#
+# Important: if you change this stuff (you shouldn't), make sure
+# _all_ our unit tests for WS URLs succeed
+#
+if not six.PY3:
+    # Python 2
+    import urlparse
+else:
+    # Python 3
+    from urllib import parse as urlparse
+
+wsschemes = ["ws", "wss"]
+urlparse.uses_relative.extend(wsschemes)
+urlparse.uses_netloc.extend(wsschemes)
+urlparse.uses_params.extend(wsschemes)
+urlparse.uses_query.extend(wsschemes)
+urlparse.uses_fragment.extend(wsschemes)
+
+__all__ = (
+    "createWsUrl",
+    "parseWsUrl",
+)
+
+def createWsUrl(hostname, port=None, isSecure=False, path=None, params=None):
+    """
+    Create a WebSocket URL from components.
+
+    :param hostname: WebSocket server hostname.
+    :type hostname: str
+
+    :param port: WebSocket service port or None (to select default
+        ports 80/443 depending on isSecure).
+    :type port: int
+
+    :param isSecure: Set True for secure WebSocket ("wss" scheme).
+    :type isSecure: bool
+
+    :param path: Path component of addressed resource (will be
+        properly URL escaped).
+    :type path: str
+
+    :param params: A dictionary of key-values to construct the query
+        component of the addressed resource (will be properly URL
+        escaped).
+    :type params: dict
+
+    :returns: str -- Constructed WebSocket URL.
+    """
+    if port is not None:
+        netloc = "%s:%d" % (hostname, port)
+    else:
+        if isSecure:
+            netloc = "%s:443" % hostname
+        else:
+            netloc = "%s:80" % hostname
+    if isSecure:
+        scheme = "wss"
+    else:
+        scheme = "ws"
+    if path is not None:
+        ppath = urllib.parse.quote(path)
+    else:
+        ppath = "/"
+    if params is not None:
+        query = urllib.parse.urlencode(params)
+    else:
+        query = None
+    return urllib.parse.urlunparse((scheme, netloc, ppath, None, query, None))
+
+
+def parseWsUrl(url):
+    """
+    Parses as WebSocket URL into it's components and returns a tuple (isSecure, host, port, resource, path, params).
+
+     - ``isSecure`` is a flag which is True for wss URLs.
+     - ``host`` is the hostname or IP from the URL.
+     - ``port`` is the port from the URL or standard port derived from
+       scheme (ws = 80, wss = 443).
+     - ``resource`` is the /resource name/ from the URL, the /path/
+       together with the (optional) /query/ component.
+     - ``path`` is the /path/ component properly unescaped.
+     - ``params`` is the /query/ component properly unescaped and
+       returned as dictionary.
+
+    :param url: A valid WebSocket URL, i.e. ``ws://localhost:9000/myresource?param1=23&param2=456``
+    :type url: str
+
+    :returns: tuple -- A tuple (isSecure, host, port, resource, path, params)
+    """
+    parsed = urlparse.urlparse(url)
+    if not parsed.hostname or parsed.hostname == "":
+        raise Exception("invalid WebSocket URL: missing hostname")
+    if parsed.scheme not in ["ws", "wss"]:
+        raise Exception("invalid WebSocket URL: bogus protocol scheme '%s'" % parsed.scheme)
+    if parsed.port is None or parsed.port == "":
+        if parsed.scheme == "ws":
+            port = 80
+        else:
+            port = 443
+    else:
+        port = int(parsed.port)
+    if parsed.fragment is not None and parsed.fragment != "":
+        raise Exception("invalid WebSocket URL: non-empty fragment '%s" % parsed.fragment)
+    if parsed.path is not None and parsed.path != "":
+        ppath = parsed.path
+        path = urllib.parse.unquote(ppath)
+    else:
+        ppath = "/"
+        path = ppath
+    if parsed.query is not None and parsed.query != "":
+        resource = ppath + "?" + parsed.query
+        params = urlparse.parse_qs(parsed.query)
+    else:
+        resource = ppath
+        params = {}
+    return parsed.scheme == "wss", parsed.hostname, port, resource, path, params

--- a/autobahn/websocket/util.py
+++ b/autobahn/websocket/util.py
@@ -55,6 +55,7 @@ __all__ = (
     "parse_url",
 )
 
+
 def create_url(hostname, port=None, isSecure=False, path=None, params=None):
     """
     Create a WebSocket URL from components.

--- a/examples/twisted/websocket/echo_multicore/server.py
+++ b/examples/twisted/websocket/echo_multicore/server.py
@@ -63,7 +63,7 @@ from twisted.internet.protocol import Factory
 from twisted.web.server import Site
 from twisted.web.static import File
 
-from autobahn.websocket.util import parse_ws_url
+from autobahn.websocket.util import parse_url
 
 from autobahn.twisted.websocket import WebSocketServerFactory, \
     WebSocketServerProtocol
@@ -377,7 +377,7 @@ if __name__ == '__main__':
 
     # parse WS URI into components and forward via options
     # FIXME: add TLS support
-    isSecure, host, wsport, resource, path, params = parse_ws_url(options.wsuri)
+    isSecure, host, wsport, resource, path, params = parse_url(options.wsuri)
     options.wsport = wsport
 
     # if not options.silence:

--- a/examples/twisted/websocket/echo_multicore/server.py
+++ b/examples/twisted/websocket/echo_multicore/server.py
@@ -63,7 +63,7 @@ from twisted.internet.protocol import Factory
 from twisted.web.server import Site
 from twisted.web.static import File
 
-from autobahn.websocket.protocol import parseWsUrl
+from autobahn.websocket.util import parse_ws_url
 
 from autobahn.twisted.websocket import WebSocketServerFactory, \
     WebSocketServerProtocol
@@ -377,7 +377,7 @@ if __name__ == '__main__':
 
     # parse WS URI into components and forward via options
     # FIXME: add TLS support
-    isSecure, host, wsport, resource, path, params = parseWsUrl(options.wsuri)
+    isSecure, host, wsport, resource, path, params = parse_ws_url(options.wsuri)
     options.wsport = wsport
 
     # if not options.silence:


### PR DESCRIPTION
The 'protocol' package imports txaio, and so unneccesarily requires anyone who uses "parseWsUrl" (e.g. a test) to initialize txaio first (and thereby choose twisted vs asyncio).

There may be other candidates in 'protocol' to move. Note that of course this breaks any existing imports of these functions...but not part of "public API" :/