### PR TITLE
fix autodoc asyncio/twisted

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -5,7 +5,24 @@
 Changelog
 =========
 
-0.12.0
+0.13.0
+------
+
+`Published 2016-03-15 <https://pypi.python.org/pypi/autobahn/0.13.0>`_
+
+* fix: better traceback logging (`#613 <https://github.com/crossbario/autobahn-python/pull/613>`_)
+* fix: unicode handling in debug messages (`#606 <https://github.com/crossbario/autobahn-python/pull/606>`_)
+* fix: return Deferred from ``run()`` (`#603 <https://github.com/crossbario/autobahn-python/pull/603>`_).
+* fix: more debug logging improvements
+* fix: more `Pattern` tests, fix edge case (`#592 <https://github.com/crossbario/autobahn-python/pull/592>`_).
+* fix: better logging from ``asyncio`` ApplicationRunner
+* new: ``disclose`` becomes a strict router-side feature (`#586 <https://github.com/crossbario/autobahn-python/issues/586>`_).
+* new: subscriber black/whitelisting using authid/authrole
+* new: asyncio websocket testee
+* new: refine Observable API (`#593 <https://github.com/crossbario/autobahn-python/pull/593>`_).
+
+
+0.12.1
 ------
 
 `Published 2016-01-30 <https://pypi.python.org/pypi/autobahn/0.12.0>`__

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -8,6 +8,29 @@ import sphinx_bootstrap_theme
 sys.path.insert(0, os.path.abspath('./_extensions'))
 sys.path.insert(0, os.path.abspath('..'))
 
+# monkey-patch txaio so that we can "use" both twisted *and* asyncio,
+# at least at import time -- this is so the autodoc stuff can
+# successfully import autobahn.twisted.* as well as autobahn.asyncio.*
+# (usually, you can only import one or the other in a single Python
+# interpreter)
+
+if True:
+   import txaio
+
+   def use_tx():
+      "monkey-patched for doc-building"
+      from txaio import tx
+      txaio._use_framework(tx)
+
+   def use_aio():
+      "monkey-patched for doc-building"
+      from txaio import aio
+      txaio._use_framework(aio)
+
+   txaio.use_twisted = use_tx
+   txaio.use_asyncio = use_aio
+
+
 extensions = [
    'sphinx.ext.autodoc',
    'sphinx.ext.doctest',

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -3,7 +3,7 @@
 
 *Open-source (MIT) real-time framework for Web, Mobile & Internet of Things.*
 
-Latest release: v\ |version| (:ref:`Changelog`)
+Latest release: v\ |version| (:ref:`changelog`)
 
 .. ifconfig:: not no_network
 


### PR DESCRIPTION
This should fix #621 for @goeddea 

There's a ton of changes in "conf.py" because I fixed the line-endings (hopefully correctly!); the "real" change is to monkey-patch txaio so that it doesn't complain if you ".use_twisted()" **and** ".use_asyncio()" in the same process. This lets us at least import both autobahn.twisted.* and autobahn.asyncio.* so the autodoc stuff is no longer sad.

I also added a changelog for 0.13.0 based purely on a "git log v0.12.1..v0.13.0". 

Works locally on Debian with a "make build" in docs/