### PR TITLE
Fix eligible/exclude authrole/authid message validation

### DIFF
--- a/autobahn/wamp/message.py
+++ b/autobahn/wamp/message.py
@@ -1374,7 +1374,7 @@ class Publish(Message):
             if type(option_eligible_authrole) != list:
                 raise ProtocolError("invalid type {0} for 'eligible_authrole' option in PUBLISH".format(type(option_eligible_authrole)))
 
-            for _authrole in option_exclude_authrole:
+            for _authrole in option_eligible_authrole:
                 if type(_authrole) == six.text_type:
                     raise ProtocolError("invalid type {0} for value in 'eligible_authrole' option in PUBLISH".format(type(_authrole)))
 

--- a/autobahn/wamp/message.py
+++ b/autobahn/wamp/message.py
@@ -1327,7 +1327,7 @@ class Publish(Message):
                 raise ProtocolError("invalid type {0} for 'exclude_authid' option in PUBLISH".format(type(option_exclude_authid)))
 
             for _authid in option_exclude_authid:
-                if type(_authid) == six.text_type:
+                if type(_authid) != six.text_type:
                     raise ProtocolError("invalid type {0} for value in 'exclude_authid' option in PUBLISH".format(type(_authid)))
 
             exclude_authid = option_exclude_authid
@@ -1339,7 +1339,7 @@ class Publish(Message):
                 raise ProtocolError("invalid type {0} for 'exclude_authrole' option in PUBLISH".format(type(option_exclude_authrole)))
 
             for _authrole in option_exclude_authrole:
-                if type(_authrole) == six.text_type:
+                if type(_authrole) != six.text_type:
                     raise ProtocolError("invalid type {0} for value in 'exclude_authrole' option in PUBLISH".format(type(_authrole)))
 
             exclude_authrole = option_exclude_authrole
@@ -1363,7 +1363,7 @@ class Publish(Message):
                 raise ProtocolError("invalid type {0} for 'eligible_authid' option in PUBLISH".format(type(option_eligible_authid)))
 
             for _authid in option_eligible_authid:
-                if type(_authid) == six.text_type:
+                if type(_authid) != six.text_type:
                     raise ProtocolError("invalid type {0} for value in 'eligible_authid' option in PUBLISH".format(type(_authid)))
 
             eligible_authid = option_eligible_authid
@@ -1375,7 +1375,7 @@ class Publish(Message):
                 raise ProtocolError("invalid type {0} for 'eligible_authrole' option in PUBLISH".format(type(option_eligible_authrole)))
 
             for _authrole in option_eligible_authrole:
-                if type(_authrole) == six.text_type:
+                if type(_authrole) != six.text_type:
                     raise ProtocolError("invalid type {0} for value in 'eligible_authrole' option in PUBLISH".format(type(_authrole)))
 
             eligible_authrole = option_eligible_authrole


### PR DESCRIPTION
Fixes immediate error raised in #618; the options seem to still be ignored though, publications with eligible_authrole set still publish to everyone.