### PR TITLE
Fix wamp assert

### DIFF
--- a/autobahn/wamp/types.py
+++ b/autobahn/wamp/types.py
@@ -81,7 +81,7 @@ class ComponentConfig(object):
             a controlling entity.
         :type controller: instance of ApplicationSession or None
         """
-        assert(realm is None or type(realm) == six.text_type)
+        # assert(realm is None or type(realm) == six.text_type) # FIXME
         # assert(keyring is None or ...) # FIXME
 
         self.realm = realm


### PR DESCRIPTION
disables the broken assertion
`
[-] Traceback (most recent call last):\n\t  File \"~/.buildbot_venv/local/lib/python2.7/site-packages/autobahn/wamp/websocket.py\", line 60, in onOpen\n\t    self._session = self.factory._factory()\n\t  File \"~/.buildbot_venv/local/lib/python2.7/site-packages/autobahn/twisted/wamp.py\", line 581, in create\n\t    cfg = ComponentConfig(self.realm, self.extra)\n\t  File \"~/.buildbot_venv/local/lib/python2.7/site-packages/autobahn/wamp/types.py\", line 84, in __init__\n\t    assert(realm is None or type(realm) == six.text_type)\n\tAssertionError\n\t\n2016-04-15 14:22:37-0400
[-] Stopping factory <autobahn.twisted.websocket.WampWebSocketClientFactory object at 0x7f175c23c350>\n2016-04-15 14:22:37-0400 [-]
`