### PR TITLE
Include autobahn.test

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -189,6 +189,7 @@ setup(
     },
     packages=[
         'autobahn',
+        'autobahn.test',
         'autobahn.wamp',
         'autobahn.wamp.test',
         'autobahn.websocket',


### PR DESCRIPTION
Addresses #650 by adding `autobahn.test` to setup.py's list of packages.