### PR TITLE
Removed `debug` kwarg from examples

### DIFF
--- a/autobahn/websocket/protocol.py
+++ b/autobahn/websocket/protocol.py
@@ -3734,8 +3734,6 @@ class WebSocketClientFactory(WebSocketFactory):
         :type headers: dict
         :param proxy: Explicit proxy server to use; a dict with ``host`` and ``port`` keys
         :type proxy: dict or None
-        :param debug: Debug mode (default: `False`).
-        :type debug: bool
         """
         self.logOctets = False
         self.logFrames = False

--- a/examples/asyncio/websocket/echo/README.md
+++ b/examples/asyncio/websocket/echo/README.md
@@ -20,10 +20,6 @@ and open
 
 in your browser.
 
-To activate debug output on the server:
-
-    python server.py debug
-
 To run the Python client
 
     python client.py ws://127.0.0.1:9000
@@ -35,9 +31,3 @@ or (Python 3)
 or (Python 2)
 
     python client_coroutines_py2.py ws://127.0.0.1:9000
-
-To activate debug output on the client
-
-    python client.py ws://127.0.0.1:9000 debug
-
-

--- a/examples/asyncio/websocket/echo/client.py
+++ b/examples/asyncio/websocket/echo/client.py
@@ -62,7 +62,7 @@ if __name__ == '__main__':
         # Trollius >= 0.3 was renamed
         import trollius as asyncio
 
-    factory = WebSocketClientFactory(u"ws://127.0.0.1:9000", debug=False)
+    factory = WebSocketClientFactory(u"ws://127.0.0.1:9000")
     factory.protocol = MyClientProtocol
 
     loop = asyncio.get_event_loop()

--- a/examples/asyncio/websocket/echo/client_coroutines.py
+++ b/examples/asyncio/websocket/echo/client_coroutines.py
@@ -60,7 +60,7 @@ class MyClientProtocol(WebSocketClientProtocol):
 
 if __name__ == '__main__':
 
-    factory = WebSocketClientFactory(u"ws://127.0.0.1:9000", debug=False)
+    factory = WebSocketClientFactory(u"ws://127.0.0.1:9000")
     factory.protocol = MyClientProtocol
 
     loop = asyncio.get_event_loop()

--- a/examples/asyncio/websocket/echo/client_coroutines_py2.py
+++ b/examples/asyncio/websocket/echo/client_coroutines_py2.py
@@ -57,7 +57,7 @@ class MyClientProtocol(WebSocketClientProtocol):
 
 if __name__ == '__main__':
 
-    factory = WebSocketClientFactory(u"ws://127.0.0.1:9000", debug=False)
+    factory = WebSocketClientFactory(u"ws://127.0.0.1:9000")
     factory.protocol = MyClientProtocol
 
     loop = trollius.get_event_loop()

--- a/examples/asyncio/websocket/slowsquare/client.py
+++ b/examples/asyncio/websocket/slowsquare/client.py
@@ -58,7 +58,7 @@ if __name__ == '__main__':
         # Trollius >= 0.3 was renamed
         import trollius as asyncio
 
-    factory = WebSocketClientFactory(u"ws://127.0.0.1:9000", debug=False)
+    factory = WebSocketClientFactory(u"ws://127.0.0.1:9000")
     factory.protocol = SlowSquareClientProtocol
 
     loop = asyncio.get_event_loop()

--- a/examples/asyncio/websocket/slowsquare/server.py
+++ b/examples/asyncio/websocket/slowsquare/server.py
@@ -58,7 +58,7 @@ class SlowSquareServerProtocol(WebSocketServerProtocol):
 
 if __name__ == '__main__':
 
-    factory = WebSocketServerFactory(u"ws://127.0.0.1:9000", debug=False)
+    factory = WebSocketServerFactory(u"ws://127.0.0.1:9000")
     factory.protocol = SlowSquareServerProtocol
 
     loop = asyncio.get_event_loop()

--- a/examples/asyncio/websocket/slowsquare/server_py2.py
+++ b/examples/asyncio/websocket/slowsquare/server_py2.py
@@ -55,7 +55,7 @@ class SlowSquareServerProtocol(WebSocketServerProtocol):
 
 if __name__ == '__main__':
 
-    factory = WebSocketServerFactory(u"ws://127.0.0.1:9000", debug=False)
+    factory = WebSocketServerFactory(u"ws://127.0.0.1:9000")
     factory.protocol = SlowSquareServerProtocol
 
     loop = trollius.get_event_loop()

--- a/examples/twisted/wamp/app/calculator/README.md
+++ b/examples/twisted/wamp/app/calculator/README.md
@@ -25,11 +25,6 @@ and open
 
 in your browser.
 
-To activate debug output, start it
-
-    python calculator.py --debug
-
-
 
 Background
 ----------

--- a/examples/twisted/wamp/app/keyvalue/README.md
+++ b/examples/twisted/wamp/app/keyvalue/README.md
@@ -30,10 +30,6 @@ and open
 
 in your browser.
 
-To activate debug output on the server, start it
-
-    python server.py debug
-
 This will show up all WAMP messages exchanged between clients and server.
 
 

--- a/examples/twisted/wamp/app/serial2ws/README.md
+++ b/examples/twisted/wamp/app/serial2ws/README.md
@@ -50,10 +50,10 @@ in your browser.
 
 **Examples**
 
-Arduino Yun running an embedded Web server and WAMP router and enabling debug output:
+Arduino Yun running an embedded Web server and WAMP router:
 
-	python serial2ws.py --debug --port /dev/ttyATH0
+	python serial2ws.py --port /dev/ttyATH0
 
-Arduino Yun running disabling the embedded Web server and connecting to an uplink WAMP router and enabling debug output:
+Arduino Yun running disabling the embedded Web server and connecting to an uplink WAMP router:
 
-	python serial2ws.py --debug --port /dev/ttyATH0 --web 0 --router ws://192.168.1.130:8080/ws
+	python serial2ws.py --port /dev/ttyATH0 --web 0 --router ws://192.168.1.130:8080/ws

--- a/examples/twisted/websocket/auth_persona/server.py
+++ b/examples/twisted/websocket/auth_persona/server.py
@@ -217,7 +217,7 @@ class PersonaServerFactory(WebSocketServerFactory):
     protocol = PersonaServerProtocol
 
     def __init__(self, url):
-        WebSocketServerFactory.__init__(self, url, debug=False)
+        WebSocketServerFactory.__init__(self, url)
 
         # map of cookies
         self._cookies = {}

--- a/examples/twisted/websocket/broadcast/README.md
+++ b/examples/twisted/websocket/broadcast/README.md
@@ -23,10 +23,6 @@ and open
 
 in your browser.
 
-To activate debug output on the server, start it
-
-    python server.py debug
-
 To use the Python client, do
 
     python client.py

--- a/examples/twisted/websocket/echo/README.md
+++ b/examples/twisted/websocket/echo/README.md
@@ -20,10 +20,6 @@ and open
 
 in your browser.
 
-To activate debug output on the server:
-
-    python server.py debug
-
 To run the Python client
 
     python client.py ws://127.0.0.1:9000
@@ -31,9 +27,3 @@ To run the Python client
 or
 
     python client_coroutines.py ws://127.0.0.1:9000
-
-To activate debug output on the client
-
-    python client.py ws://127.0.0.1:9000 debug
-
-

--- a/examples/twisted/websocket/echo/client.py
+++ b/examples/twisted/websocket/echo/client.py
@@ -63,7 +63,7 @@ if __name__ == '__main__':
 
     log.startLogging(sys.stdout)
 
-    factory = WebSocketClientFactory(u"ws://127.0.0.1:9000", debug=False)
+    factory = WebSocketClientFactory(u"ws://127.0.0.1:9000")
     factory.protocol = MyClientProtocol
 
     reactor.connectTCP("127.0.0.1", 9000, factory)

--- a/examples/twisted/websocket/echo/client_coroutines.py
+++ b/examples/twisted/websocket/echo/client_coroutines.py
@@ -70,7 +70,7 @@ if __name__ == '__main__':
 
     log.startLogging(sys.stdout)
 
-    factory = WebSocketClientFactory(u"ws://127.0.0.1:9000", debug=False)
+    factory = WebSocketClientFactory(u"ws://127.0.0.1:9000")
     factory.protocol = MyClientProtocol
 
     reactor.connectTCP("127.0.0.1", 9000, factory)

--- a/examples/twisted/websocket/echo/server.py
+++ b/examples/twisted/websocket/echo/server.py
@@ -58,7 +58,7 @@ if __name__ == '__main__':
 
     log.startLogging(sys.stdout)
 
-    factory = WebSocketServerFactory(u"ws://127.0.0.1:9000", debug=False)
+    factory = WebSocketServerFactory(u"ws://127.0.0.1:9000")
     factory.protocol = MyServerProtocol
     # factory.setProtocolOptions(maxConnections=2)
 

--- a/examples/twisted/websocket/echo_compressed/README.md
+++ b/examples/twisted/websocket/echo_compressed/README.md
@@ -19,17 +19,9 @@ in your browser.
 > Note: Currently (06/04/2013), the only browsers implementing WebSocket `permessage-deflate` are [Chrome Canary](https://www.google.com/intl/en/chrome/browser/canary.html) and [Chromium (Dev Channel)](http://www.chromium.org/getting-involved/dev-channel).
 > To enable, go to `chrome://flags/` and enable the "experimental WebSocket implementation".
 
-To activate debug output on the server, start it
-
-    python server.py debug
-
 To run the Python client, do
 
     python client.py ws://127.0.0.1:9000
-
-To activate debug output on the client, start it
-
-    python client.py ws://127.0.0.1:9000 debug
 
 
 Advanced Usage

--- a/examples/twisted/websocket/echo_multicore/server_reuseport.py
+++ b/examples/twisted/websocket/echo_multicore/server_reuseport.py
@@ -90,7 +90,7 @@ if __name__ == '__main__':
 
     log.startLogging(sys.stdout)
 
-    factory = WebSocketServerFactory(u"ws://127.0.0.1:9000", debug=False)
+    factory = WebSocketServerFactory(u"ws://127.0.0.1:9000")
     factory.protocol = MyServerProtocol
 
     # reactor.listenTCP(9000, factory)

--- a/examples/twisted/websocket/echo_service/README.md
+++ b/examples/twisted/websocket/echo_service/README.md
@@ -29,8 +29,4 @@ and open
 
 in your browser.
 
-To activate debug output on the server, start it
-
-    twistd echows -d
-
 This will show up all WebSocket messages exchanged between clients and server.

--- a/examples/twisted/websocket/echo_site/README.md
+++ b/examples/twisted/websocket/echo_site/README.md
@@ -16,8 +16,4 @@ and open
 
 in your browser.
 
-To activate debug output on the server, start it
-
-    python server.py debug
-
 This will show up all WebSocket messages exchanged between clients and server.

--- a/examples/twisted/websocket/echo_site_tls/README.md
+++ b/examples/twisted/websocket/echo_site_tls/README.md
@@ -16,8 +16,4 @@ and open
 
 in your browser.
 
-To activate debug output on the server, start it
-
-    python server.py debug
-
 This will show up all WebSocket messages exchanged between clients and server.

--- a/examples/twisted/websocket/echo_tls/README.md
+++ b/examples/twisted/websocket/echo_tls/README.md
@@ -19,10 +19,6 @@ in your browser.
 
 Click to install the server certificate and start the echo client example.
 
-To activate debug output on the server, start it
-
-    python server.py debug
-
 This will show up all WAMP messages exchanged between clients and server.
 
 To run the Python client, do

--- a/examples/twisted/websocket/echo_tls/client.py
+++ b/examples/twisted/websocket/echo_tls/client.py
@@ -59,7 +59,7 @@ if __name__ == '__main__':
 
     # create a WS server factory with our protocol
     ##
-    factory = WebSocketClientFactory(options.url, debug=False)
+    factory = WebSocketClientFactory(options.url)
     factory.protocol = EchoClientProtocol
 
     # SSL client context: default

--- a/examples/twisted/websocket/echo_variants/Makefile
+++ b/examples/twisted/websocket/echo_variants/Makefile
@@ -1,2 +1,2 @@
 client:
-	PYTHONPATH=../../../../autobahn python client.py ws://127.0.0.1:9000 debug
+	PYTHONPATH=../../../../autobahn python client.py ws://127.0.0.1:9000

--- a/examples/twisted/websocket/echo_variants/README.md
+++ b/examples/twisted/websocket/echo_variants/README.md
@@ -14,18 +14,8 @@ and open
 
 in your browser.
 
-To activate debug output on the server, start it
-
-    python server.py debug
-
 This will show up all WAMP messages exchanged between clients and server.
 
 To run the Python client, do
 
     python client.py ws://127.0.0.1:9000
-
-To activate debug output on the client, start it
-
-    python client.py ws://127.0.0.1:9000 debug
-
-

--- a/examples/twisted/websocket/echo_wsfallbacks/README.md
+++ b/examples/twisted/websocket/echo_wsfallbacks/README.md
@@ -25,10 +25,6 @@ and open
 
 in your browser. Open the JS console to see if the WebSocket connection was successful.
 
-To activate debug output on the server, start it
-
-    python server.py debug
-
 
 Here is a typical browser log when the Flash implementation kicks in:
 

--- a/examples/twisted/websocket/echo_wsgi/README.md
+++ b/examples/twisted/websocket/echo_wsgi/README.md
@@ -16,8 +16,4 @@ and open
 
 in your browser.
 
-To activate debug output on the server, start it
-
-    python server.py debug
-
 This will show up all WebSocket messages exchanged between clients and server.

--- a/examples/twisted/websocket/ping/README.md
+++ b/examples/twisted/websocket/ping/README.md
@@ -25,8 +25,3 @@ in your browser.
 To run the Python client, do
 
     python client.py wss://localhost:9000
-
-For both server and client you can add `debug` to the command line to **activate wire logging** of all sent and received WebSocket messages.
-
-
-

--- a/examples/twisted/websocket/ping/client.py
+++ b/examples/twisted/websocket/ping/client.py
@@ -59,7 +59,7 @@ if __name__ == '__main__':
         print("Need the WebSocket server address, i.e. ws://127.0.0.1:9000")
         sys.exit(1)
 
-    factory = WebSocketClientFactory(sys.argv[1], debug='debug' in sys.argv)
+    factory = WebSocketClientFactory(sys.argv[1])
     factory.protocol = PingClientProtocol
     connectWS(factory)
 

--- a/examples/twisted/websocket/ping/server.py
+++ b/examples/twisted/websocket/ping/server.py
@@ -63,8 +63,8 @@ class PingServerProtocol(WebSocketServerProtocol):
 
 class PingServerFactory(WebSocketServerFactory):
 
-    def __init__(self, uri, debug):
-        WebSocketServerFactory.__init__(self, uri, debug=debug)
+    def __init__(self, uri):
+        WebSocketServerFactory.__init__(self, uri)
         self.pingsSent = {}
         self.pongsReceived = {}
 
@@ -76,8 +76,7 @@ if __name__ == '__main__':
     contextFactory = ssl.DefaultOpenSSLContextFactory('keys/server.key',
                                                       'keys/server.crt')
 
-    factory = PingServerFactory(u"wss://127.0.0.1:9000",
-                                debug='debug' in sys.argv)
+    factory = PingServerFactory(u"wss://127.0.0.1:9000")
 
     factory.protocol = PingServerProtocol
     listenWS(factory, contextFactory)

--- a/examples/twisted/websocket/pingpong_keepalive/client.py
+++ b/examples/twisted/websocket/pingpong_keepalive/client.py
@@ -42,7 +42,7 @@ if __name__ == '__main__':
         print("Need the WebSocket server address, i.e. ws://127.0.0.1:9000")
         sys.exit(1)
 
-    factory = WebSocketClientFactory(sys.argv[1], debug=True)
+    factory = WebSocketClientFactory(sys.argv[1])
     factory.protocol = WebSocketClientProtocol
     connectWS(factory)
 

--- a/examples/twisted/websocket/reconnecting/client.py
+++ b/examples/twisted/websocket/reconnecting/client.py
@@ -79,7 +79,7 @@ if __name__ == '__main__':
 
     log.startLogging(sys.stdout)
 
-    factory = MyClientFactory(u"ws://127.0.0.1:9000", debug=False)
+    factory = MyClientFactory(u"ws://127.0.0.1:9000")
 
     reactor.connectTCP("127.0.0.1", 9000, factory)
     reactor.run()

--- a/examples/twisted/websocket/reconnecting/server.py
+++ b/examples/twisted/websocket/reconnecting/server.py
@@ -58,7 +58,7 @@ if __name__ == '__main__':
 
     log.startLogging(sys.stdout)
 
-    factory = WebSocketServerFactory(u"ws://127.0.0.1:9000", debug=False)
+    factory = WebSocketServerFactory(u"ws://127.0.0.1:9000")
     factory.protocol = MyServerProtocol
 
     reactor.listenTCP(9000, factory)

--- a/examples/twisted/websocket/slowsquare/client.py
+++ b/examples/twisted/websocket/slowsquare/client.py
@@ -59,7 +59,7 @@ if __name__ == '__main__':
 
     log.startLogging(sys.stdout)
 
-    factory = WebSocketClientFactory(u"ws://127.0.0.1:9000", debug=False)
+    factory = WebSocketClientFactory(u"ws://127.0.0.1:9000")
     factory.protocol = SlowSquareClientProtocol
 
     reactor.connectTCP("127.0.0.1", 9000, factory)

--- a/examples/twisted/websocket/slowsquare/server.py
+++ b/examples/twisted/websocket/slowsquare/server.py
@@ -70,7 +70,7 @@ if __name__ == '__main__':
 
     log.startLogging(sys.stdout)
 
-    factory = WebSocketServerFactory(u"ws://127.0.0.1:9000", debug=False)
+    factory = WebSocketServerFactory(u"ws://127.0.0.1:9000")
     factory.protocol = SlowSquareServerProtocol
 
     reactor.listenTCP(9000, factory)

--- a/examples/twisted/websocket/wrapping/README.md
+++ b/examples/twisted/websocket/wrapping/README.md
@@ -69,7 +69,6 @@ There are a couple of optional arguments to `WrappingWebSocketClientFactory` for
 
  * `enableCompression` can be used to enable/disable WebSocket compression ("permessage-deflate")
  * `autoFragmentSize` can be used to automatically fragment the stream data into WebSocket frames of at most this size
- * `debug` enables/disables debug log output
 
 You can find a complete example for both client and server in these files:
 
@@ -100,12 +99,12 @@ You can find a complete example for both client and server in these files:
 
  1. `"autobahn:tcp\:localhost\:9000:url=ws\:// localhost\:9000"`
  1. `"autobahn:tcp\:localhost\:9000:url=ws\:// localhost\:9000:compress=false"`
- 1. `"autobahn:tcp\:localhost\:9000:url=ws\:// localhost\:9000:autofrag=4096:debug=true"`
+ 1. `"autobahn:tcp\:localhost\:9000:url=ws\:// localhost\:9000:autofrag=4096"`
 
 *Example Server Endpoint Descriptors*
 
  1. `"autobahn:tcp\:9000:url=ws\://localhost\:9000"`
- 1. `"autobahn:tcp\:9000:url=ws\://localhost\:9000:autofrag=4096:debug=true"`
+ 1. `"autobahn:tcp\:9000:url=ws\://localhost\:9000:autofrag=4096"`
  1. `"autobahn:tcp\:9000\:interface\=0.0.0.0:url=ws\://localhost\:9000:compress=true"`
 
 

--- a/examples/twisted/websocket/wrapping/client.py
+++ b/examples/twisted/websocket/wrapping/client.py
@@ -52,7 +52,6 @@ if __name__ == '__main__':
     wrappedFactory = Factory.forProtocol(HelloClientProtocol)
     factory = WrappingWebSocketClientFactory(wrappedFactory,
                                              u"ws://127.0.0.1:9000",
-                                             debug=False,
                                              enableCompression=False,
                                              autoFragmentSize=1024)
 

--- a/examples/twisted/websocket/wrapping/server.py
+++ b/examples/twisted/websocket/wrapping/server.py
@@ -52,7 +52,6 @@ if __name__ == '__main__':
     wrappedFactory = Factory.forProtocol(HelloServerProtocol)
     factory = WrappingWebSocketServerFactory(wrappedFactory,
                                              u"ws://127.0.0.1:9000",
-                                             debug=False,
                                              enableCompression=False,
                                              autoFragmentSize=1024)
 

--- a/examples/twisted/websocket/wxpython/server.py
+++ b/examples/twisted/websocket/wxpython/server.py
@@ -49,7 +49,7 @@ class BroadcastServerFactory(WebSocketServerFactory):
     protocol = BroadcastServerProtocol
 
     def __init__(self, url):
-        WebSocketServerFactory.__init__(self, url, debug=False)
+        WebSocketServerFactory.__init__(self, url)
         self.clients = []
 
     def register(self, client):


### PR DESCRIPTION
Some examples contain a nonexistent `debug` kwarg in `__init__`.