### PR TITLE
Add showServerVersion controlling full/partial version in headers

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,14 @@
 Changelog
 =========
 
+master
+------
+
+*Not yet published.*
+
+* new: added ``showServerVersion`` (defaulting to ``False``) to control whether the full Autobahn version is shown in the ``X-Powered-By:`` header.
+
+
 0.14.0
 ------
 


### PR DESCRIPTION
This defaults to False, and so will only show that we're using "Autobahn" and not the precise version.

(See https://github.com/crossbario/crossbar/issues/770 for discussion)