### PR TITLE
putChild() calls need bytes

### DIFF
--- a/examples/twisted/websocket/auth_persona/server.py
+++ b/examples/twisted/websocket/auth_persona/server.py
@@ -235,9 +235,10 @@ if __name__ == '__main__':
     # we serve static files under "/" ..
     root = File(".")
 
-    # .. and our WebSocket server under "/ws"
+    # .. and our WebSocket server under "/ws" (note that Twisted uses
+    # bytes for URIs)
     resource = WebSocketResource(factory)
-    root.putChild(u"ws", resource)
+    root.putChild(b"ws", resource)
 
     # run both under one Twisted Web Site
     site = Site(root)

--- a/examples/twisted/websocket/echo/server.py
+++ b/examples/twisted/websocket/echo/server.py
@@ -62,5 +62,7 @@ if __name__ == '__main__':
     factory.protocol = MyServerProtocol
     # factory.setProtocolOptions(maxConnections=2)
 
+    # note to self: if using putChild, the child must be bytes...
+
     reactor.listenTCP(9000, factory)
     reactor.run()

--- a/examples/twisted/websocket/echo_service/echows/echoservice.py
+++ b/examples/twisted/websocket/echo_service/echows/echoservice.py
@@ -70,8 +70,9 @@ class EchoService(service.Service):
         webdir = os.path.abspath(pkg_resources.resource_filename("echows", "web"))
         root = File(webdir)
 
-        # and our WebSocket server under "/ws"
-        root.putChild(u"ws", resource)
+        # and our WebSocket server under "/ws" (note that Twisted uses
+        # bytes for URIs)
+        root.putChild(b"ws", resource)
 
         # both under one Twisted Web Site
         site = Site(root)

--- a/examples/twisted/websocket/echo_site/server.py
+++ b/examples/twisted/websocket/echo_site/server.py
@@ -58,8 +58,9 @@ if __name__ == '__main__':
     # we server static files under "/" ..
     root = File(".")
 
-    # and our WebSocket server under "/ws"
-    root.putChild(u"ws", resource)
+    # and our WebSocket server under "/ws" (note that Twisted uses
+    # bytes for URIs)
+    root.putChild(b"ws", resource)
 
     # both under one Twisted Web Site
     site = Site(root)

--- a/examples/twisted/websocket/echo_site_tls/server.py
+++ b/examples/twisted/websocket/echo_site_tls/server.py
@@ -58,8 +58,9 @@ if __name__ == '__main__':
     # we server static files under "/" ..
     root = File(".")
 
-    # and our WebSocket server under "/ws"
-    root.putChild(u"ws", resource)
+    # and our WebSocket server under "/ws" (note that Twisted uses
+    # bytes for URIs)
+    root.putChild(b"ws", resource)
 
     # both under one Twisted Web Site
     site = Site(root)

--- a/examples/twisted/websocket/multiproto/server2.py
+++ b/examples/twisted/websocket/multiproto/server2.py
@@ -72,9 +72,10 @@ if __name__ == '__main__':
     # Establish a dummy root resource
     root = Data("", "text/plain")
 
-    # and our WebSocket servers under different paths ..
-    root.putChild("echo1", resource1)
-    root.putChild("echo2", resource2)
+    # and our WebSocket servers under different paths .. (note that
+    # Twisted uses bytes for URIs)
+    root.putChild(b"echo1", resource1)
+    root.putChild(b"echo2", resource2)
 
     # both under one Twisted Web Site
     site = Site(root)

--- a/examples/twisted/websocket/ping/server.py
+++ b/examples/twisted/websocket/ping/server.py
@@ -84,7 +84,8 @@ if __name__ == '__main__':
     resource = WebSocketResource(factory)
 
     root = File(".")
-    root.putChild(u"ws", resource)
+    # note that Twisted uses bytes for URLs, which mostly affects Python3
+    root.putChild(b"ws", resource)
     site = Site(root)
 
     reactor.listenSSL(8080, site, contextFactory)

--- a/examples/twisted/websocket/pingpong_keepalive/server.py
+++ b/examples/twisted/websocket/pingpong_keepalive/server.py
@@ -52,7 +52,7 @@ if __name__ == '__main__':
     resource = WebSocketResource(factory)
 
     root = File(".")
-    root.putChild(u"ws", resource)
+    root.putChild(b"ws", resource)
     site = Site(root)
 
     reactor.listenTCP(8080, site)


### PR DESCRIPTION
To work properly on Python3, `putChild()` calls need bytes for their URL fragments, as Twisted uses bytes for URIs.