### PR TITLE
Issue701 just pin

### DIFF
--- a/autobahn/twisted/resource.py
+++ b/autobahn/twisted/resource.py
@@ -158,6 +158,5 @@ class WebSocketResource(object):
                 data += "%s: %s\x0d\x0a" % (h[0], ",".join(h[1]))
             data += "\x0d\x0a"
         protocol.dataReceived(data)
-        transport.resumeProducing()
 
         return NOT_DONE_YET

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ with open('README.rst') as f:
 # as we make claims to support older Twisted!)
 extras_require_twisted = [
     "zope.interface>=3.6.0",        # Zope Public License
-    "Twisted>=12.1.0"               # MIT license
+    "Twisted >= 12.1.0, <= 16.1.1"  # MIT license
 ]
 
 # asyncio dependencies


### PR DESCRIPTION
I was premature in merging the "fix" (#703) for #701. So, this reverts that merge and then pins the Twisted dependency <= 16.2.0 until we have a better solution.