### PR TITLE
first cut

### DIFF
--- a/autobahn/asyncio/rawsocket.py
+++ b/autobahn/asyncio/rawsocket.py
@@ -415,8 +415,10 @@ class WampRawSocketServerFactory(WampRawSocketFactory):
            :class:`autobahn.wamp.interfaces.ISerializer`.
         :type serializers: list
         """
-        assert(callable(factory))
-        self._factory = factory
+        if callable(factory):
+            self._factory = factory
+        else:
+            self._factory = lambda: factory
 
         if serializers is None:
             serializers = get_serializes()
@@ -444,8 +446,10 @@ class WampRawSocketClientFactory(WampRawSocketFactory):
            :class:`autobahn.wamp.interfaces.ISerializer`.
         :type serializer: obj
         """
-        assert(callable(factory))
-        self._factory = factory
+        if callable(factory):
+            self._factory = factory
+        else:
+            self._factory = lambda: factory
 
         if serializer is None:
             serializers = get_serializes()

--- a/autobahn/twisted/rawsocket.py
+++ b/autobahn/twisted/rawsocket.py
@@ -361,8 +361,10 @@ class WampRawSocketServerFactory(WampRawSocketFactory):
            :class:`autobahn.wamp.interfaces.ISerializer`.
         :type serializers: list
         """
-        assert(callable(factory))
-        self._factory = factory
+        if callable(factory):
+            self._factory = factory
+        else:
+            self._factory = lambda: factory
 
         if serializers is None:
             serializers = []
@@ -424,8 +426,10 @@ class WampRawSocketClientFactory(WampRawSocketFactory):
            :class:`autobahn.wamp.interfaces.ISerializer`.
         :type serializer: obj
         """
-        assert(callable(factory))
-        self._factory = factory
+        if callable(factory):
+            self._factory = factory
+        else:
+            self._factory = lambda: factory
 
         if serializer is None:
 

--- a/autobahn/wamp/websocket.py
+++ b/autobahn/wamp/websocket.py
@@ -227,9 +227,10 @@ class WampWebSocketFactory(object):
            :class:`autobahn.wamp.interfaces.ISerializer`.
         :type serializers: list
         """
-        if not callable(factory):
-            raise Exception(u'factory must be a callable')
-        self._factory = factory
+        if callable(factory):
+            self._factory = factory
+        else:
+            self._factory = lambda: factory
 
         if serializers is None:
             serializers = []

--- a/examples/twisted/wamp/work/test_lifecycle.py
+++ b/examples/twisted/wamp/work/test_lifecycle.py
@@ -1,0 +1,39 @@
+import txaio
+txaio.use_twisted()
+
+from twisted.internet import reactor
+from twisted.internet.endpoints import TCP4ClientEndpoint
+from twisted.application.internet import ClientService
+
+from autobahn.wamp.types import ComponentConfig
+from autobahn.twisted.wamp import ApplicationSession, WampWebSocketClientFactory
+
+
+class MyComponent(ApplicationSession):
+
+    def onConnect(self):
+        self.log.info('transport connected')
+        self.join(self.config.realm)
+
+    def onChallenge(self, challenge):
+        self.log.info('authentication challenge received')
+
+    def onJoin(self, details):
+        self.log.info('session joined: {}'.format(details))
+
+    def onLeave(self, details):
+        self.log.info('session left: {}'.format(details))
+
+    def onDisconnect(self):
+        self.log.info('transport disconnected')
+
+
+if __name__ == '__main__':
+    txaio.start_logging(level='info')
+
+    session = MyComponent(ComponentConfig(u'realm1', {}))
+    transport = WampWebSocketClientFactory(session, url=u'ws://localhost:8080/ws')
+    endpoint = TCP4ClientEndpoint(reactor, 'localhost', 8080)
+    service = ClientService(endpoint, transport)
+    service.startService()
+    reactor.run()

--- a/examples/twisted/wamp/work/test_lifecycle.py
+++ b/examples/twisted/wamp/work/test_lifecycle.py
@@ -2,38 +2,78 @@ import txaio
 txaio.use_twisted()
 
 from twisted.internet import reactor
+from twisted.internet.defer import inlineCallbacks
 from twisted.internet.endpoints import TCP4ClientEndpoint
 from twisted.application.internet import ClientService
 
 from autobahn.wamp.types import ComponentConfig
 from autobahn.twisted.wamp import ApplicationSession, WampWebSocketClientFactory
 
+def add2(a, b):
+    print('add2 called: {} {}'.format(a, b))
+    return a + b
 
-class MyComponent(ApplicationSession):
+
+class MyAppSession(ApplicationSession):
+
+    def __init__(self, config):
+        ApplicationSession.__init__(self, config)
+        self._countdown = 5
 
     def onConnect(self):
         self.log.info('transport connected')
+
+        # lets join a realm .. normally, we would also specify
+        # how we would like to authenticate here
         self.join(self.config.realm)
 
     def onChallenge(self, challenge):
         self.log.info('authentication challenge received')
 
+    @inlineCallbacks
     def onJoin(self, details):
         self.log.info('session joined: {}'.format(details))
 
+        yield self.register(add2, u'com.example.add2')
+
+        for i in range(10):
+            res = yield self.call(u'com.example.add2', 23, i)
+            self.log.info('result: {}'.format(res))
+
+        yield self.leave()
+
     def onLeave(self, details):
         self.log.info('session left: {}'.format(details))
+        self.disconnect()
 
     def onDisconnect(self):
         self.log.info('transport disconnected')
+        # this is to clean up stuff. it is not our business to
+        # possibly reconnect the underlying connection
+        self._countdown -= 1
+        if self._countdown <= 0:
+            try:
+                reactor.stop()
+            except ReactorNotRunning:
+                pass
 
 
 if __name__ == '__main__':
     txaio.start_logging(level='info')
 
-    session = MyComponent(ComponentConfig(u'realm1', {}))
+    # create a WAMP session object. this is reused across multiple
+    # reconnects (if automatically reconnected)
+    session = MyAppSession(ComponentConfig(u'realm1', {}))
+
+    # create a WAMP transport factory
     transport = WampWebSocketClientFactory(session, url=u'ws://localhost:8080/ws')
+
+    # create a connecting endpoint
     endpoint = TCP4ClientEndpoint(reactor, 'localhost', 8080)
+
+    # create and start an automatically reconnecting client
     service = ClientService(endpoint, transport)
     service.startService()
+
+    # enter the event loop
     reactor.run()


### PR DESCRIPTION
This change allows WAMP session instances, instead of only WAMP session factories being supplied to WAMP transport factories. A transport factory will create a new session when a callable was provided, and else reuse the existing session object.