### PR TITLE
Correcting minor typo Twisted ApplicationRunner

### DIFF
--- a/autobahn/twisted/wamp.py
+++ b/autobahn/twisted/wamp.py
@@ -282,7 +282,7 @@ class ApplicationRunner(object):
             # this is automatically reconnecting
             service = ClientService(client, transport_factory)
             service.startService()
-            d = service. whenConnected()
+            d = service.whenConnected()
         else:
             # this is only connecting once!
             self.log.debug('using t.i.e.connect()')


### PR DESCRIPTION
Removing erroneous space typo in autobahn.twisted.wamp:ApplicationRunner

It still worked, but looked like that it isn't how you normally style things