### PR TITLE
asyncio: ws: allow yield from onConnect callback

### DIFF
--- a/autobahn/asyncio/websocket.py
+++ b/autobahn/asyncio/websocket.py
@@ -199,7 +199,7 @@ class WebSocketServerProtocol(WebSocketAdapterProtocol, protocol.WebSocketServer
         try:
             res = self.onConnect(request)
             if yields(res):
-                res = yield from res
+                asyncio.async(res)
         except ConnectionDeny as e:
             self.failHandshake(e.reason, e.code)
         except Exception as e:

--- a/autobahn/asyncio/websocket.py
+++ b/autobahn/asyncio/websocket.py
@@ -198,8 +198,8 @@ class WebSocketServerProtocol(WebSocketAdapterProtocol, protocol.WebSocketServer
         # noinspection PyBroadException
         try:
             res = self.onConnect(request)
-            # if yields(res):
-            #  res = yield from res
+            if yields(res):
+                res = yield from res
         except ConnectionDeny as e:
             self.failHandshake(e.reason, e.code)
         except Exception as e:


### PR DESCRIPTION
Now onConnect callback of WebSocketServerProtocol can be a coroutine. 