### PR TITLE
Newapi improvements

### DIFF
--- a/autobahn/twisted/component.py
+++ b/autobahn/twisted/component.py
@@ -285,7 +285,6 @@ class Component(component.Component):
         transport_endpoint = _create_transport_endpoint(reactor, transport_config['endpoint'])
         return transport_endpoint.connect(transport_factory)
 
-
     # XXX think: is it okay to use inlineCallbacks (in this
     # twisted-only file) even though we're using txaio?
     @inlineCallbacks

--- a/autobahn/twisted/component.py
+++ b/autobahn/twisted/component.py
@@ -289,7 +289,7 @@ class Component(component.Component):
     # XXX think: is it okay to use inlineCallbacks (in this
     # twisted-only file) even though we're using txaio?
     @inlineCallbacks
-    def start(self, reactor):
+    def start(self, reactor=None):
         """
         This starts the Component, which means it will start connecting
         (and re-connecting) to its configured transports. A Component
@@ -356,11 +356,14 @@ class Component(component.Component):
                         # information."
                         for (lib, fn, reason) in e.args[0]:
                             self.log.error(u"TLS failure: {reason}", reason=reason)
-                            self.log.error(u"Marking this transport as failed")
-                            transport.failed()
+                        self.log.error(u"Marking this transport as failed")
+                        transport.failed()
                     else:
                         f = txaio.create_failure()
-                        self.log.error(u'Connection failed: {error}', error=txaio.failure_message(f))
+                        self.log.error(
+                            u'Connection failed: {error}',
+                            error=txaio.failure_message(f),
+                        )
                         # some types of errors should probably have
                         # stacktraces logged immediately at error
                         # level, e.g. SyntaxError?

--- a/autobahn/twisted/component.py
+++ b/autobahn/twisted/component.py
@@ -225,7 +225,7 @@ class Component(component.Component):
 
     log = txaio.make_logger()
 
-    session = ApplicationSession
+    session_factory = ApplicationSession
     """
     The factory of the session we will instantiate.
     """

--- a/autobahn/twisted/component.py
+++ b/autobahn/twisted/component.py
@@ -286,8 +286,8 @@ class Component(component.Component):
         return transport_endpoint.connect(transport_factory)
 
 
-# XXX fixme we can't use inlineCallbacks, can we? or can we because
-# we're in a "twisted-only" class?
+    # XXX think: is it okay to use inlineCallbacks (in this
+    # twisted-only file) even though we're using txaio?
     @inlineCallbacks
     def start(self, reactor):
         """

--- a/autobahn/twisted/component.py
+++ b/autobahn/twisted/component.py
@@ -62,6 +62,7 @@ from autobahn.wamp.exception import ApplicationError
 
 __all__ = ('Component')
 
+
 def _is_ssl_error(e):
     """
     Internal helper.
@@ -193,7 +194,7 @@ def _create_transport_endpoint(reactor, endpoint_config):
                 # FIXME: create TLS context from configuration
                 if IOpenSSLClientConnectionCreator.providedBy(tls):
                     # eg created from twisted.internet.ssl.optionsForClientTLS()
-                    context = IOpenSSLClientComponentCreator(tls)
+                    context = IOpenSSLClientConnectionCreator(tls)
 
                 elif isinstance(tls, CertificateOptions):
                     context = tls
@@ -274,7 +275,7 @@ class Component(component.Component):
             raise ValueError(
                 "'endpoint' configuration must be a dict or IStreamClientEndpoint"
                 " provider"
-        )
+            )
 
     def _connect_transport(self, reactor, transport_config, session_factory):
         """
@@ -339,11 +340,11 @@ class Component(component.Component):
                     # to also add, for example, things like
                     # SyntaxError
                     if isinstance(e, ApplicationError):
-#                        self.log.error(u"{error}: {message}", error=e.error, message=e.message)
                         if e.error in [u'wamp.error.no_such_realm']:
                             reconnect = False
                             self.log.error(u"Fatal error, not reconnecting")
                             raise
+                        # self.log.error(u"{error}: {message}", error=e.error, message=e.message)
                     elif _is_ssl_error(e):
                         # Quoting pyOpenSSL docs: "Whenever
                         # [SSL.Error] is raised directly, it has a
@@ -403,7 +404,6 @@ def _run(reactor, components):
         log.debug("Component error: {tb}", tb=txaio.failure_format_traceback(f))
         return None
 
-
     # all components are started in parallel
     dl = []
     for c in components:
@@ -411,8 +411,6 @@ def _run(reactor, components):
         d = c.start(reactor)
         txaio.add_callbacks(d, partial(component_success, c), component_failure)
         dl.append(d)
-
-
     d = txaio.gather(dl, consume_exceptions=False)
 
     def all_done(arg):

--- a/autobahn/twisted/component.py
+++ b/autobahn/twisted/component.py
@@ -230,6 +230,29 @@ class Component(component.Component):
     The factory of the session we will instantiate.
     """
 
+    def _check_native_endpoint(self, endpoint):
+        self.log.error("_check_native_endpoint")
+        if isinstance(endpoint, dict):
+            return
+        if IStreamClientEndpoint.providedBy(endpoint):
+            return
+        if 'tls' in endpoint:
+            tls = endpoint['tls']
+            if isinstance(tls, (dict, bool)):
+                return
+            if IOpenSSLClientConnectionCreator.providedBy(tls):
+                return
+            if isinstance(tls, CertificateOptions):
+                return
+            raise ValueError(
+                "'tls' configuration must be a dict, CertificateOptions or"
+                " IOpenSSLClientConnectionCreator provider"
+            )
+        raise ValueError(
+            "'endpoint' configuration must be a dict or IStreamClientEndpoint"
+            " provider"
+        )
+
     def _connect_transport(self, reactor, transport_config, session_factory):
         """
         Create and connect a WAMP-over-XXX transport.

--- a/autobahn/twisted/component.py
+++ b/autobahn/twisted/component.py
@@ -238,7 +238,8 @@ class Component(component.Component):
         transport_endpoint = _create_transport_endpoint(reactor, transport_config['endpoint'])
         return transport_endpoint.connect(transport_factory)
 
-# XXX fixme we can't use inlineCallbacks, can we?
+# XXX fixme we can't use inlineCallbacks, can we? or can we because
+# we're in a "twisted-only" class?
     @inlineCallbacks
     def start(self, reactor):
         """

--- a/autobahn/twisted/component.py
+++ b/autobahn/twisted/component.py
@@ -39,7 +39,7 @@ try:
     _TLS = True
     from twisted.internet.endpoints import SSL4ClientEndpoint
     from twisted.internet.ssl import optionsForClientTLS, CertificateOptions
-    from twisted.internet.interfaces import IOpenSSLClientComponentCreator
+    from twisted.internet.interfaces import IOpenSSLClientConnectionCreator
 except ImportError:
     _TLS = False
 
@@ -168,7 +168,7 @@ def _create_transport_endpoint(reactor, endpoint_config):
                     raise RuntimeError('TLS configured in transport, but TLS support is not installed (eg OpenSSL?)')
 
                 # FIXME: create TLS context from configuration
-                if IOpenSSLClientComponentCreator.providedBy(tls):
+                if IOpenSSLClientConnectionCreator.providedBy(tls):
                     # eg created from twisted.internet.ssl.optionsForClientTLS()
                     context = IOpenSSLClientComponentCreator(tls)
 

--- a/autobahn/twisted/component.py
+++ b/autobahn/twisted/component.py
@@ -284,6 +284,7 @@ class Component(component.Component):
         transport_endpoint = _create_transport_endpoint(reactor, transport_config['endpoint'])
         return transport_endpoint.connect(transport_factory)
 
+
 # XXX fixme we can't use inlineCallbacks, can we? or can we because
 # we're in a "twisted-only" class?
     @inlineCallbacks
@@ -312,7 +313,7 @@ class Component(component.Component):
 
         reconnect = True
 
-        self.log.info('Entering re-connect loop')
+        self.log.debug('Entering re-connect loop')
 
         while reconnect:
             # cycle through all transports forever ..

--- a/autobahn/twisted/wamp.py
+++ b/autobahn/twisted/wamp.py
@@ -133,7 +133,7 @@ class ApplicationRunner(object):
         self.proxy = proxy
         self.headers = headers
 
-    def run(self, make, start_reactor=True, auto_reconnect=False):
+    def run(self, make, start_reactor=True, auto_reconnect=False, log_level='info'):
         """
         Run the application component.
 
@@ -160,7 +160,7 @@ class ApplicationRunner(object):
             from twisted.internet import reactor
             txaio.use_twisted()
             txaio.config.loop = reactor
-            txaio.start_logging(level='info')
+            txaio.start_logging(level=log_level)
 
         if callable(make):
             # factory for use ApplicationSession

--- a/autobahn/twisted/wamp.py
+++ b/autobahn/twisted/wamp.py
@@ -684,7 +684,7 @@ class Session(ApplicationSession):
     def onDisconnect(self):
         return self.on_disconnect()
 
-    def on_join(self):
+    def on_join(self, details):
         pass
 
     def on_leave(self, details):

--- a/autobahn/twisted/wamp.py
+++ b/autobahn/twisted/wamp.py
@@ -663,9 +663,20 @@ if service:
 
 # new API
 class Session(ApplicationSession):
+    # shim that lets us present pep8 API for user-classes to override,
+    # but also backwards-compatible for existing code using
+    # ApplicationSession "directly".
+
+    # XXX note to self: if we release this as "the" API, then we can
+    # change all internal Autobahn calls to .on_join() etc, and make
+    # ApplicationSession a subclass of Session -- and it can then be
+    # separate deprecated and removed, ultimately, if desired.
 
     def onJoin(self, details):
         return self.on_join(details)
+
+    # XXX def onChallenge(self, )
+    # XXX def onOpen ??
 
     def onLeave(self, details):
         return self.on_leave(details)

--- a/autobahn/util.py
+++ b/autobahn/util.py
@@ -701,8 +701,8 @@ class ObservableMixin(object):
         if self._listeners is None:
             self._listeners = dict()
         if event not in self._listeners:
-            self._listeners[event] = set()
-        self._listeners[event].add(handler)
+            self._listeners[event] = []
+        self._listeners[event].append(handler)
 
     def off(self, event=None, handler=None):
         """
@@ -748,7 +748,7 @@ class ObservableMixin(object):
 
         self._check_event(event)
         res = []
-        for handler in self._listeners.get(event, set()):
+        for handler in self._listeners.get(event, []):
             future = txaio.as_future(handler, *args, **kwargs)
             res.append(future)
         if self._parent is not None:

--- a/autobahn/wamp/component.py
+++ b/autobahn/wamp/component.py
@@ -211,7 +211,7 @@ class Component(ObservableMixin):
     TYPE_MAIN = 1
     TYPE_SETUP = 2
 
-    def __init__(self, main=None, setup=None, transports=None, config=None, realm=u'realm1'):
+    def __init__(self, main=None, setup=None, transports=None, config=None, realm=u'public'):
         """
 
         :param main: A callable that runs user code for the component. The component will be
@@ -227,6 +227,7 @@ class Component(ObservableMixin):
         :type setup: callable
         :param transports: Transport configurations for creating transports.
         :type transports: None or unicode or list
+
         :param config: Session configuration.
         :type config: None or dict
 
@@ -285,7 +286,7 @@ class Component(ObservableMixin):
         # XXX decide if 'realm' is part of the transport config, or a
         # Component 'global' parameter
         self._realm = realm
-        self._extra = None
+        self._extra = None  # XXX FIXME
 
     def _can_reconnect(self):
         # check if any of our transport has any reconnect attempt left

--- a/autobahn/wamp/component.py
+++ b/autobahn/wamp/component.py
@@ -220,6 +220,7 @@ class Component(ObservableMixin):
             self._transports.append(Transport(idx, transport))
             idx += 1
 
+        # XXX FIXME
         self._realm = u'realm1'
         self._extra = None
 

--- a/autobahn/wamp/component.py
+++ b/autobahn/wamp/component.py
@@ -141,7 +141,7 @@ class Component(ObservableMixin):
     TYPE_MAIN = 1
     TYPE_SETUP = 2
 
-    def __init__(self, main=None, setup=None, transports=None, config=None):
+    def __init__(self, main=None, setup=None, transports=None, config=None, realm=u'realm1'):
         """
 
         :param main: A callable that runs user code for the component. The component will be
@@ -220,8 +220,9 @@ class Component(ObservableMixin):
             self._transports.append(Transport(idx, transport))
             idx += 1
 
-        # XXX FIXME
-        self._realm = u'realm1'
+        # XXX decide if 'realm' is part of the transport config, or a
+        # Component 'global' parameter
+        self._realm = realm
         self._extra = None
 
     def _can_reconnect(self):

--- a/autobahn/wamp/component.py
+++ b/autobahn/wamp/component.py
@@ -380,7 +380,7 @@ class Component(ObservableMixin):
 
                 # listen on leave events
                 def on_leave(session, details):
-                    self.log.info("session on_leave: {details}", details=details)
+                    self.log.debug("session on_leave: {details}", details=details)
                     # this could be a "leave" that's expected e.g. our
                     # main() exited, or it could be an error
                     if not txaio.is_called(done):

--- a/autobahn/wamp/component.py
+++ b/autobahn/wamp/component.py
@@ -231,7 +231,7 @@ class Component(ObservableMixin):
         :param config: Session configuration.
         :type config: None or dict
 
-        :param realm: the realm to join (XXX move to transport config? or config, above?)
+        :param realm: the realm to join
         :type realm: unicode
 
         """
@@ -283,8 +283,6 @@ class Component(ObservableMixin):
             self._transports.append(Transport(idx, transport))
             idx += 1
 
-        # XXX decide if 'realm' is part of the transport config, or a
-        # Component 'global' parameter
         self._realm = realm
         self._extra = None  # XXX FIXME
 

--- a/autobahn/wamp/component.py
+++ b/autobahn/wamp/component.py
@@ -268,7 +268,7 @@ class Component(ObservableMixin):
 
                         def main_success(_):
                             self.log.debug("main_success")
-                            txaio.resolve(done, None)
+                            session.leave()
 
                         def main_error(err):
                             self.log.debug("main_error: {err}", err=err)

--- a/autobahn/wamp/websocket.py
+++ b/autobahn/wamp/websocket.py
@@ -86,7 +86,12 @@ class WampWebSocketProtocol(object):
         """
         try:
             for msg in self._serializer.unserialize(payload, isBinary):
-                self.log.trace("WAMP RECV: message={message}, session={session}, authid={authid}", authid=self._session._authid, session=self._session._session_id, message=msg)
+                self.log.trace(
+                    "WAMP RECV: message={message}, session={session}, authid={authid}",
+                    authid=self._session._authid,
+                    session=self._session._session_id,
+                    message=msg,
+                )
                 self._session.onMessage(msg)
 
         except ProtocolError as e:

--- a/examples/router/.crossbar/config-with-tls.json
+++ b/examples/router/.crossbar/config-with-tls.json
@@ -1,4 +1,5 @@
 {
+    "version": 2,
     "workers": [
         {
             "type": "router",
@@ -10,11 +11,19 @@
                             "name": "anonymous",
                             "permissions": [
                                 {
-                                    "uri": "*",
-                                    "publish": true,
-                                    "subscribe": true,
-                                    "call": true,
-                                    "register": true
+                                    "uri": "",
+                                    "match": "prefix",
+                                    "allow": {
+                                        "call": true,
+                                        "register": true,
+                                        "publish": true,
+                                        "subscribe": true
+                                    },
+                                    "disclose": {
+                                        "caller": false,
+                                        "publisher": false
+                                    },
+                                    "cache": true
                                 }
                             ]
                         }
@@ -63,11 +72,11 @@
                     "type": "websocket",
                     "endpoint": {
                         "type": "tcp",
-                        "interface": "127.0.0.1",
+                        "interface": "localhost",
                         "port": 8083,
                         "tls": {
-                            "key": "../../twisted/wamp/pubsub/tls/server.key",
-                            "certificate": "../../twisted/wamp/pubsub/tls/server.crt"
+                            "key": "server.key",
+                            "certificate": "server.crt"
                         }
                     }
                 }

--- a/examples/router/.crossbar/config.json
+++ b/examples/router/.crossbar/config.json
@@ -1,1 +1,1 @@
-config-no-tls.json
+config-with-tls.json

--- a/examples/twisted/wamp/work/newapi/test_newapi_twisted.py
+++ b/examples/twisted/wamp/work/newapi/test_newapi_twisted.py
@@ -1,0 +1,122 @@
+from __future__ import print_function
+import os
+import txaio
+
+from twisted.internet.defer import inlineCallbacks
+from twisted.internet.endpoints import TCP4ClientEndpoint
+from twisted.internet.endpoints import SSL4ClientEndpoint
+from twisted.internet.endpoints import UNIXClientEndpoint
+from twisted.internet.ssl import optionsForClientTLS, trustRootFromCertificates, Certificate, CertificateOptions
+from twisted.internet import reactor
+
+from autobahn.twisted.component import Component, run
+from autobahn.twisted.util import sleep
+from autobahn.twisted.wamp import Session
+
+# This uses the new-api with various Twisted native objects. For the
+# Unix socket things, you'll have to add a transport to "config.json"
+# like this:
+#    {
+#        "type": "websocket",
+#        "endpoint": {
+#            "type": "unix",
+#            "path": "unix-websocket"
+#        }
+#    }
+# ...then, the socket will appear in the .crossbar directory as
+# "unix-websocket". Everything in here presumes you're using the
+# "example/router/.crossbar" with config.json linked to either
+# "config-no-tls.json" or "config-tls.json"
+
+
+class Foo(Session):
+    def __init__(self, *args, **kw):
+        1 / 0
+
+@inlineCallbacks
+def setup(reactor, session):
+    print('bob created', session)
+
+    def on_join(session, details):
+        print('bob joined', session, details)
+
+    session.on('join', on_join)
+    yield sleep(5)
+    print("bob done sleeping")
+#    session.leave()
+
+
+if __name__ == '__main__':
+    cert_fname = os.path.join(
+        os.path.split(__file__)[0],
+        '..', '..', '..', '..', 'router', '.crossbar', 'ca.cert.pem',
+    )
+    inter_cert_fname = os.path.join(
+        os.path.split(__file__)[0],
+        '..', '..', '..', '..', 'router', '.crossbar', 'intermediate.cert.pem',
+    )
+
+    tls_transport = {
+        "type": "websocket",
+        "url": "wss://127.0.0.1:8083/ws",
+        "endpoint": SSL4ClientEndpoint(
+            reactor, '127.0.0.1', 8083,
+            optionsForClientTLS(
+                u'localhost',
+                # XXX why do I need BOTH the intermediate and actual
+                # cert? Did I create the CA/intermediate certificates
+                # incorrectly?
+                trustRoot=trustRootFromCertificates(
+                    [
+                        Certificate.loadPEM(open(cert_fname).read()),
+                        Certificate.loadPEM(open(inter_cert_fname).read()),
+                    ]
+                ),
+            ),
+        )
+    }
+
+    unix_transport = {
+        "type": "websocket",
+        "url": "ws://localhost/ws",
+        "endpoint": UNIXClientEndpoint(
+            reactor,
+            os.path.join(
+                os.path.split(__file__)[0],
+                '..', '..', '..', '..', 'router', '.crossbar', 'intermediate.cert.pem',
+            )
+        )
+    }
+
+    # this one should produce handshake errors etc, good for testing error-cases:
+    tls_transport_untrusted = {
+        "type": "websocket",
+        "url": "wss://127.0.0.1:8083/ws",
+        "endpoint": SSL4ClientEndpoint(
+            reactor,
+            '127.0.0.1',
+            8080,
+            optionsForClientTLS(u'localhost'),
+        ),
+    }
+
+    clearnet_transport = {
+        "type": "websocket",
+        "url": "ws://127.0.0.1:8080/ws",
+        "endpoint": TCP4ClientEndpoint(reactor, 'localhost', 8080)
+    }
+
+    transports = [
+        tls_transport_untrusted,
+        tls_transport,
+        clearnet_transport,
+    ]
+
+    # try main= vs. setup= to see different exit behavior
+    component = Component(main=setup, transports=transports, realm=u'crossbardemo')
+    #component = Component(setup=setup, transports=transports, realm=u'crossbardemo')
+
+    # can add this confirm logging of more error-cases
+    #component.session_factory = Foo
+    txaio.start_logging(level='info')
+    run(component)


### PR DESCRIPTION
This adds a few improvements to new-api things, and a few cleanups. The main features are:

 - change from "verify config" to "normalize config" (more common code, and e.g. to support extracting an endpoint from the url)
 - support for Twisted native objects in the config
 - bug in signagure in Session object
 - another example (including unix sockets, TLS) in `work/newapi`
 - fix bugs in notifications (use `list` since `set` objects can't get re-sized while iterating them)
 - call `set_valid_events`
 - upgrade TLS example-router config to version 2

I'm happy to squash this more if you like.