### PR TITLE
Make tests compatible with pytest3

### DIFF
--- a/autobahn/asyncio/test/test_asyncio_rawsocket.py
+++ b/autobahn/asyncio/test/test_asyncio_rawsocket.py
@@ -1,9 +1,6 @@
 import pytest
 import os
 
-if not os.environ.get('USE_ASYNCIO', False):
-    raise pytest.skip("Only for asyncio")
-
 from unittest import TestCase, main
 try:
     from unittest.mock import Mock, call
@@ -15,6 +12,7 @@ from autobahn.asyncio.util import get_serializers
 from autobahn.wamp import message
 
 
+@pytest.mark.skipif(os.environ.get('USE_ASYNCIO', False), reason="Only for asyncio")
 class Test(TestCase):
 
     def test_sers(self):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-[pytest]
+[tool:pytest]
 norecursedirs = autobahn/twisted/*
 
 [bdist_wheel]


### PR DESCRIPTION
Tests can now be run under pytest 2.9 and 3.0