### PR TITLE
Fixes derive_key()'s keylen argument documentation

### DIFF
--- a/autobahn/wamp/auth.py
+++ b/autobahn/wamp/auth.py
@@ -224,7 +224,7 @@ def derive_key(secret, salt, iterations=1000, keylen=32):
     :type salt: bytes or unicode
     :param iterations: Number of iterations of derivation algorithm to run.
     :type iterations: int
-    :param keylen: Length of the key to derive in bits.
+    :param keylen: Length of the key to derive in bytes.
     :type keylen: int
 
     :return: The derived key in Base64 encoding.


### PR DESCRIPTION
This patch corrects the documentation in the comments for the keylen argument of the derive_key() function to specify that the key length is expressed in bytes rather than bits.

I realize that this is a pretty minor inconsistency, but it caused some issues for me recently when I was trying to implement equivalent functionality in Java for an Android app. I couldn't find documentation on what units are used for the keylen value in the WAMP-CRA authentication challenge message and ended up consulting this code as a reference implementation. The comments suggested that the value is expressed in bits, but after some debugging we came to the conclusion that the value is expressed in bytes rather than bits.