### PR TITLE
Issue747 future loops

### DIFF
--- a/autobahn/asyncio/rawsocket.py
+++ b/autobahn/asyncio/rawsocket.py
@@ -69,14 +69,14 @@ class PrefixProtocol(asyncio.Protocol):
         self.log.debug('RawSocker Asyncio: Connection made with peer {peer}', peer=self.peer)
         self._buffer = b''
         self._header = None
-        self._wait_closed = asyncio.Future()
+        self._wait_closed = txaio.create_future()
 
     @property
     def is_closed(self):
         if hasattr(self, '_wait_closed'):
             return self._wait_closed
         else:
-            f = asyncio.Future()
+            f = txaio.create_future()
             f.set_result(True)
             return f
 

--- a/autobahn/asyncio/test/test_asyncio_websocket.py
+++ b/autobahn/asyncio/test/test_asyncio_websocket.py
@@ -2,13 +2,17 @@ import pytest
 import os
 
 # because py.test tries to collect it as a test-case
-from asyncio.test_utils import TestLoop as AsyncioTestLoop
-from unittest import TestCase
+try:
+    from asyncio.test_utils import TestLoop as AsyncioTestLoop
+except ImportError:
+    from trollius.test_utils import TestLoop as AsyncioTestLoop
 try:
     from unittest.mock import Mock
 except ImportError:
     from mock import Mock
+
 from autobahn.asyncio.websocket import WebSocketServerFactory
+from unittest import TestCase
 
 
 @pytest.mark.usefixtures("event_loop")  # ensure we have pytest_asyncio installed

--- a/autobahn/asyncio/test/test_asyncio_websocket.py
+++ b/autobahn/asyncio/test/test_asyncio_websocket.py
@@ -1,0 +1,30 @@
+import pytest
+import os
+
+# because py.test tries to collect it as a test-case
+from asyncio.test_utils import TestLoop as AsyncioTestLoop
+from unittest import TestCase
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
+from autobahn.asyncio.websocket import WebSocketServerFactory
+
+
+@pytest.mark.usefixtures("event_loop")  # ensure we have pytest_asyncio installed
+@pytest.mark.skipif(os.environ.get('USE_ASYNCIO', False), reason="Only for asyncio")
+class Test(TestCase):
+
+    @pytest.mark.asyncio(forbid_global_loop=True)
+    def test_websocket_custom_loop(self):
+
+        def time_gen():
+            yield
+            yield
+
+        loop = AsyncioTestLoop(time_gen)
+        factory = WebSocketServerFactory(loop=loop)
+        server = factory()
+        transport = Mock()
+
+        server.connection_made(transport)

--- a/autobahn/asyncio/websocket.py
+++ b/autobahn/asyncio/websocket.py
@@ -100,7 +100,7 @@ class WebSocketAdapterProtocol(asyncio.Protocol):
         self.transport = None
 
     def _consume(self):
-        self.waiter = Future()
+        self.waiter = Future(loop=self.factory.loop or txaio.config.loop)
 
         def process(_):
             while len(self.receive_queue):

--- a/autobahn/asyncio/websocket.py
+++ b/autobahn/asyncio/websocket.py
@@ -239,6 +239,8 @@ class WebSocketServerFactory(WebSocketAdapterFactory, protocol.WebSocketServerFa
     Base class for asyncio-based WebSocket server factories.
     """
 
+    protocol = WebSocketServerProtocol
+
     def __init__(self, *args, **kwargs):
         """
         In addition to all arguments to the constructor of

--- a/setup.py
+++ b/setup.py
@@ -130,12 +130,13 @@ extras_require_dev = [
     'pyenchant>=1.6.6',                 # LGPL
     'sphinxcontrib-spelling>=2.1.2',    # BSD
     'sphinx_rtd_theme>=0.1.9',          # BSD
+    'pytest_asyncio',
 ]
 
 # for testing by users with "python setup.py test" (not Tox, which we use)
 test_requirements = [
     "pytest>=2.8.6",        # MIT license
-    "mock>=1.3.0"           # BSD license
+    "mock>=1.3.0",          # BSD license
 ]
 
 


### PR DESCRIPTION
Okay, here's a straw-man solution for #747 -- it at least honors the "loop=" arg to WebSockets (unless that's None, in which case it uses `txaio`'s loop, if configured). Includes a simple test.

Something puzzling: I had to change the `protocol=` attribute for the factory to actually get an asyncio-specific protocol instance from the factory...

I also changed a couple RawSocket bare `Future()`s