### PR TITLE
Fix twisted 17

### DIFF
--- a/autobahn/twisted/resource.py
+++ b/autobahn/twisted/resource.py
@@ -139,10 +139,14 @@ class WebSocketResource(object):
             transport.protocol = protocol
         protocol.makeConnection(transport)
 
-        # On Twisted 16.3.0+, the transport is paused whilst the existing
-        # request is served; there won't be any requests after us so we can
-        # just resume this ourselves.
-        if hasattr(transport, "resumeProducing"):
+        # On Twisted 16+, the transport is paused whilst the existing
+        # request is served; there won't be any requests after us so
+        # we can just resume this ourselves.
+        # 17.1 version
+        if hasattr(transport, "_networkProducer"):
+            transport._networkProducer.resumeProducing()
+        # 16.x version
+        elif hasattr(transport, "resumeProducing"):
             transport.resumeProducing()
 
         # We recreate the request and forward the raw data. This is somewhat

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
 envlist =
     flake8
-    py27-{tw121,tw132,tw154,tw165,twtrunk,asyncio}
-    pypy-{tw121,tw132,tw154,tw165,twtrunk,asyncio}
-    py33-{tw154,tw165,twtrunk,asyncio}
-    py34-{tw154,tw165,twtrunk,asyncio}
-    py35-{tw154,tw165,twtrunk,asyncio}
+    py27-{tw121,tw132,tw154,tw165,tw171,twtrunk,asyncio}
+    pypy-{tw121,tw132,tw154,tw165,tw171,twtrunk,asyncio}
+    py33-{tw154,tw165,tw171,twtrunk,asyncio}
+    py34-{tw154,tw165,tw171,twtrunk,asyncio}
+    py35-{tw154,tw165,tw171,twtrunk,asyncio}
 
 
 [flake8]
@@ -31,6 +31,7 @@ deps =
     tw132: twisted==13.2.0
     tw154: twisted==15.4.0
     tw165: twisted==16.5.0
+    tw171: twisted==17.1.0
     twtrunk: https://github.com/twisted/twisted/archive/trunk.zip
     {tw121,tw132,tw154,tw165,twtrunk}: pytest-twisted
 
@@ -48,7 +49,7 @@ commands =
     coverage --version
     asyncio: coverage run --source {envsitepackagesdir}/autobahn/ {envbindir}/py.test {envsitepackagesdir}/autobahn/
     tw121,tw132,tw154: coverage run {envbindir}/trial autobahn
-    tw165,twtrunk: coverage run -m twisted.trial autobahn
+    tw165,tw171,twtrunk: coverage run -m twisted.trial autobahn
     coverage report
 
 whitelist_externals = sh
@@ -57,7 +58,7 @@ setenv =
     PYUBJSON_NO_EXTENSION = 1
     SODIUM_INSTALL = bundled
     asyncio: USE_ASYNCIO = 1
-    tw121,tw132,tw154,tw165,twtrunk: USE_TWISTED = 1
+    tw121,tw132,tw154,tw165,tw171,twtrunk: USE_TWISTED = 1
 
 
 [testenv:flake8]


### PR DESCRIPTION
Haven't extensively tested, but see https://github.com/django/daphne/commit/b65140b1589a02fc8187bd750b01f3eff43d2140

Also adds Twisted 17.1.0 to the Tox matrix.