### PR TITLE
decorators, new-api

### DIFF
--- a/autobahn/twisted/component.py
+++ b/autobahn/twisted/component.py
@@ -50,7 +50,7 @@ import txaio
 from autobahn.twisted.websocket import WampWebSocketClientFactory
 from autobahn.twisted.rawsocket import WampRawSocketClientFactory
 
-from autobahn.wamp import component, types
+from autobahn.wamp import component
 
 from autobahn.twisted.util import sleep
 from autobahn.twisted.wamp import Session

--- a/autobahn/twisted/component.py
+++ b/autobahn/twisted/component.py
@@ -28,14 +28,11 @@
 from __future__ import absolute_import, print_function
 
 import itertools
-from functools import partial
 
 from twisted.internet.defer import inlineCallbacks  # XXX FIXME?
-from twisted.python.failure import Failure
 from twisted.internet.interfaces import IStreamClientEndpoint
 from twisted.internet.endpoints import UNIXClientEndpoint
 from twisted.internet.endpoints import TCP4ClientEndpoint
-from twisted.internet.error import ReactorNotRunning
 
 try:
     _TLS = True
@@ -382,80 +379,6 @@ class Component(component.Component):
         return self._session.leave()
 
 
-# XXX this should move to autobahn/wamp/component.py or somewhere
-# generic as this same implementation will work for asyncio
-def _run(reactor, components):
-    """
-    Internal helper. Use "run" method.
-
-    This is called by react() so any errors coming out of this should
-    be handled properly. Logging will already be started.
-    """
-    # let user pass a single component to run, too
-    # XXX probably want IComponent? only demand it, here and below?
-    if isinstance(components, Component):
-        components = [components]
-
-    if type(components) != list:
-        raise ValueError(
-            '"components" must be a list of Component objects - encountered'
-            ' {0}'.format(type(components))
-        )
-
-    for c in components:
-        if not isinstance(c, Component):
-            raise ValueError(
-                '"components" must be a list of Component objects - encountered'
-                'item of type {0}'.format(type(c))
-            )
-
-    # validation complete; proceed with startup
-    log = txaio.make_logger()
-
-    def component_success(comp, arg):
-        log.debug("Component '{c}' successfully completed: {arg}", c=comp, arg=arg)
-        return arg
-
-    def component_failure(comp, f):
-        log.error("Component '{c}' error: {msg}", c=comp, msg=txaio.failure_message(f))
-        log.debug("Component error: {tb}", tb=txaio.failure_format_traceback(f))
-        # double-check: is a component-failure still fatal to the
-        # startup process (because we passed consume_exception=False
-        # to gather() below?)
-        return None
-
-    def component_start(comp):
-        # the future from start() errbacks if we fail, or callbacks
-        # when the component is considered "done" (so maybe never)
-        d = comp.start(reactor)
-        txaio.add_callbacks(
-            d,
-            partial(component_success, comp),
-            partial(component_failure, comp),
-        )
-        return d
-
-    # note that these are started in parallel -- maybe we want to add
-    # a "connected" signal to components so we could start them in the
-    # order they're given to run() as "a" solution to dependencies.
-    dl = []
-    for comp in components:
-        d = component_start(comp)
-        dl.append(d)
-    done_d = txaio.gather(dl, consume_exceptions=False)
-
-    def all_done(arg):
-        log.debug("All components ended; stopping reactor")
-        if isinstance(arg, Failure):
-            log.error("Something went wrong: {log_failure}", failure=arg)
-        try:
-            reactor.stop()
-        except ReactorNotRunning:
-            pass
-    txaio.add_callbacks(done_d, all_done, all_done)
-    return done_d
-
-
 def run(components, log_level='info'):
     """
     High-level API to run a series of components.
@@ -485,4 +408,4 @@ def run(components, log_level='info'):
     # txaio.start_logging() what happens if we call it again?)
     if log_level is not None:
         txaio.start_logging(level=log_level)
-    react(_run, (components, ))
+    react(component._run, (components, ))

--- a/autobahn/twisted/test/test_component.py
+++ b/autobahn/twisted/test/test_component.py
@@ -28,16 +28,100 @@ from __future__ import absolute_import
 
 import os
 import unittest
+from mock import Mock, patch
 
 if os.environ.get('USE_TWISTED', False):
     from autobahn.twisted.component import Component
+    from zope.interface import directlyProvides
+    from autobahn.wamp.message import Welcome, Goodbye
+    from autobahn.wamp.serializer import JsonSerializer
+    from twisted.internet.interfaces import IStreamClientEndpoint
+    from twisted.internet.defer import inlineCallbacks, succeed
+    from twisted.internet.task import Clock
+    from txaio.testutil import replace_loop
+
+    class ConnectionTests(unittest.TestCase):
+
+        def setUp(self):
+            pass
+
+        @patch('autobahn.twisted.component.sleep', return_value=succeed(None))
+        @inlineCallbacks
+        def test_successful_connect(self, fake_sleep):
+            endpoint = Mock()
+            joins = []
+
+            def joined(session, details):
+                joins.append((session, details))
+                return session.leave()
+            directlyProvides(endpoint, IStreamClientEndpoint)
+            component = Component(
+                transports={
+                    "type": "websocket",
+                    "url": "ws://127.0.0.1/ws",
+                    "endpoint": endpoint,
+                }
+            )
+            component.on('join', joined)
+
+            def connect(factory, **kw):
+                proto = factory.buildProtocol('boom')
+                proto.makeConnection(Mock())
+
+                from autobahn.websocket.protocol import WebSocketProtocol
+                from base64 import b64encode
+                from hashlib import sha1
+                key = proto.websocket_key + WebSocketProtocol._WS_MAGIC
+                proto.data = (
+                    b"HTTP/1.1 101 Switching Protocols\x0d\x0a"
+                    b"Upgrade: websocket\x0d\x0a"
+                    b"Connection: upgrade\x0d\x0a"
+                    b"Sec-Websocket-Protocol: wamp.2.json\x0d\x0a"
+                    b"Sec-Websocket-Accept: " + b64encode(sha1(key).digest()) + b"\x0d\x0a\x0d\x0a"
+                )
+                proto.processHandshake()
+
+                from autobahn.wamp import role
+                features = role.RoleBrokerFeatures(
+                    publisher_identification=True,
+                    pattern_based_subscription=True,
+                    session_meta_api=True,
+                    subscription_meta_api=True,
+                    subscriber_blackwhite_listing=True,
+                    publisher_exclusion=True,
+                    subscription_revocation=True,
+                    payload_transparency=True,
+                    payload_encryption_cryptobox=True,
+                )
+
+                msg = Welcome(123456, dict(broker=features), realm=u'realm')
+                serializer = JsonSerializer()
+                data, is_binary = serializer.serialize(msg)
+                proto.onMessage(data, is_binary)
+
+                msg = Goodbye()
+                proto.onMessage(*serializer.serialize(msg))
+                proto.onClose(True, 100, "some old reason")
+
+                return succeed(proto)
+            endpoint.connect = connect
+
+            # XXX it would actually be nicer if we *could* support
+            # passing a reactor in here, but the _batched_timer =
+            # make_batched_timer() stuff (slash txaio in general)
+            # makes this "hard".
+            reactor = Clock()
+            with replace_loop(reactor):
+                yield component.start()
+                self.assertTrue(len(joins), 1)
+                # make sure we fire all our time-outs
+                reactor.advance(3600)
 
     class InvalidTransportConfigs(unittest.TestCase):
 
         def test_invalid_key(self):
             with self.assertRaises(ValueError) as ctx:
                 Component(
-                    main=lambda r, s: None,
                     transports=dict(
                         foo='bar',  # totally invalid key
                     ),
@@ -47,7 +131,6 @@ if os.environ.get('USE_TWISTED', False):
         def test_invalid_key_transport_list(self):
             with self.assertRaises(ValueError) as ctx:
                 Component(
-                    main=lambda r, s: None,
                     transports=[
                         dict(type='websocket', url='ws://127.0.0.1/ws'),
                         dict(foo='bar'),  # totally invalid key
@@ -58,7 +141,6 @@ if os.environ.get('USE_TWISTED', False):
         def test_invalid_serializer_key(self):
             with self.assertRaises(ValueError) as ctx:
                 Component(
-                    main=lambda r, s: None,
                     transports=[
                         {
                             "url": "ws://127.0.0.1/ws",
@@ -71,7 +153,6 @@ if os.environ.get('USE_TWISTED', False):
         def test_invalid_serializer(self):
             with self.assertRaises(ValueError) as ctx:
                 Component(
-                    main=lambda r, s: None,
                     transports=[
                         {
                             "url": "ws://127.0.0.1/ws",
@@ -84,7 +165,6 @@ if os.environ.get('USE_TWISTED', False):
         def test_invalid_serializer_type_0(self):
             with self.assertRaises(ValueError) as ctx:
                 Component(
-                    main=lambda r, s: None,
                     transports=[
                         {
                             "url": "ws://127.0.0.1/ws",
@@ -97,7 +177,6 @@ if os.environ.get('USE_TWISTED', False):
         def test_invalid_serializer_type_1(self):
             with self.assertRaises(ValueError) as ctx:
                 Component(
-                    main=lambda r, s: None,
                     transports=[
                         {
                             "url": "ws://127.0.0.1/ws",
@@ -110,7 +189,6 @@ if os.environ.get('USE_TWISTED', False):
         def test_invalid_type_key(self):
             with self.assertRaises(ValueError) as ctx:
                 Component(
-                    main=lambda r, s: None,
                     transports=[
                         {
                             "type": "bad",
@@ -122,7 +200,6 @@ if os.environ.get('USE_TWISTED', False):
         def test_invalid_type(self):
             with self.assertRaises(ValueError) as ctx:
                 Component(
-                    main=lambda r, s: None,
                     transports=[
                         "foo"
                     ]
@@ -132,7 +209,6 @@ if os.environ.get('USE_TWISTED', False):
         def test_no_url(self):
             with self.assertRaises(ValueError) as ctx:
                 Component(
-                    main=lambda r, s: None,
                     transports=[
                         {
                             "type": "websocket",

--- a/autobahn/twisted/wamp.py
+++ b/autobahn/twisted/wamp.py
@@ -54,7 +54,8 @@ __all__ = [
     'Service',
 
     # new API
-    'Session'
+    'Session',
+    # 'run',  # should probably move this method to here? instead of component
 ]
 
 try:

--- a/autobahn/util.py
+++ b/autobahn/util.py
@@ -681,9 +681,10 @@ class ObservableMixin(object):
         """
         if self._valid_events and event not in self._valid_events:
             raise RuntimeError(
-                "Invalid event '{event}'. Expected one of: {events}",
-                event=event,
-                events=', '.join(self._valid_events),
+                "Invalid event '{event}'. Expected one of: {events}".format(
+                    event=event,
+                    events=', '.join(self._valid_events),
+                )
             )
 
     def on(self, event, handler):

--- a/autobahn/wamp/component.py
+++ b/autobahn/wamp/component.py
@@ -516,6 +516,42 @@ class Component(ObservableMixin):
 
         return done
 
+    def on_join(self, fn):
+        """
+        A decorator as a shortcut for listening for 'join' events.
+
+        For example::
+
+           @component.on_join
+           def joined(session, details):
+               print("Session {} joined: {}".format(session, details))
+        """
+        self.on('join', fn)
+
+    def on_leave(self, fn):
+        """
+        A decorator as a shortcut for listening for 'leave' events.
+        """
+        self.on('leave', fn)
+
+    def on_connect(self, fn):
+        """
+        A decorator as a shortcut for listening for 'connect' events.
+        """
+        self.on('connect', fn)
+
+    def on_disconnect(self, fn):
+        """
+        A decorator as a shortcut for listening for 'disconnect' events.
+        """
+        self.on('disconnect', fn)
+
+    def on_ready(self, fn):
+        """
+        A decorator as a shortcut for listening for 'ready' events.
+        """
+        self.on('ready', fn)
+
 
 def _run(reactor, components):
     """

--- a/autobahn/wamp/message.py
+++ b/autobahn/wamp/message.py
@@ -294,7 +294,7 @@ class Hello(Message):
         :param resume_token: The secure authorisation token to resume the session.
         :type resume_token: unicode or None
         """
-        assert(realm is None or type(realm) == six.text_type)
+        assert(realm is None or isinstance(realm, six.text_type))
         assert(type(roles) == dict)
         assert(len(roles) > 0)
         for role in roles:
@@ -446,25 +446,25 @@ class Hello(Message):
                         details[u'roles'][role.ROLE] = {u'features': {}}
                     details[u'roles'][role.ROLE][u'features'][six.u(feature)] = getattr(role, feature)
 
-        if self.authmethods:
+        if self.authmethods is not None:
             details[u'authmethods'] = self.authmethods
 
-        if self.authid:
+        if self.authid is not None:
             details[u'authid'] = self.authid
 
-        if self.authrole:
+        if self.authrole is not None:
             details[u'authrole'] = self.authrole
 
-        if self.authextra:
+        if self.authextra is not None:
             details[u'authextra'] = self.authextra
 
         if self.resumable is not None:
             details[u'resumable'] = self.resumable
 
-        if self.resume_session:
+        if self.resume_session is not None:
             details[u'resume-session'] = self.resume_session
 
-        if self.resume_token:
+        if self.resume_token is not None:
             details[u'resume-token'] = self.resume_token
 
         return [Hello.MESSAGE_TYPE, self.realm, details]

--- a/autobahn/wamp/protocol.py
+++ b/autobahn/wamp/protocol.py
@@ -504,8 +504,15 @@ class ApplicationSession(BaseSession):
 
                 def success(arg):
                     # XXX also: handle async
-                    self.fire('leave', self, details)
-                    return arg
+                    d = self.fire('leave', self, details)
+
+                    def return_arg(_):
+                        return arg
+
+                    def _error(e):
+                        return self._swallow_error(e, "While firing 'leave' event")
+                    txaio.add_callbacks(d, return_arg, _error)
+                    return d
 
                 def _error(e):
                     return self._swallow_error(e, "While firing onLeave")
@@ -1077,7 +1084,7 @@ class ApplicationSession(BaseSession):
 
         def _error(e):
             return self._swallow_error(e, "While firing onDisconnect")
-        txaio.add_callbacks(d, None, _error)
+        txaio.add_callbacks(d, success, _error)
 
     def onChallenge(self, challenge):
         """
@@ -1124,7 +1131,7 @@ class ApplicationSession(BaseSession):
         """
         Implements :func:`autobahn.wamp.interfaces.ISession.onDisconnect`
         """
-        pass  # return self.fire('disconnect', self, True)
+        pass
 
     def publish(self, topic, *args, **kwargs):
         """


### PR DESCRIPTION
(This is based on #795 so there's really only one new commit here: https://github.com/meejah/AutobahnPython/commit/c3812044980bd184c520b53154232d5ba882dee4).

This is a decorator-API for "join" etc events. So then you can do this:

```python
component = Component(...)

@component.on_join
def joined(session, details):
    print("Session {} joined: {}".format(session, details))
```

The story for "going to production" (e.g. having crossbar run this component for you) is to list the "joined" method as an on_join listener via the "function" container type: https://github.com/crossbario/crossbar/commit/210bc88f6f68e45e423576931ef9c949ccb69a03