### PR TITLE
A decorator-based API for subscribe and register

### DIFF
--- a/autobahn/wamp/component.py
+++ b/autobahn/wamp/component.py
@@ -300,6 +300,50 @@ class Component(ObservableMixin):
     The factory of the session we will instantiate.
     """
 
+    def subscribe(self, topic, options=None):
+        """
+        A decorator as a shortcut for subscribing during on-join
+
+        For example::
+
+            @component.subscribe(
+                u"some.topic",
+                options=SubscribeOptions(match=u'prefix'),
+            )
+            def topic(*args, **kw):
+                print("some.topic({}, {}): event received".format(args, kw))
+        """
+        assert options is None or isinstance(options, types.SubscribeOptions)
+
+        def decorator(fn):
+
+            def do_subscription(session, details):
+                return session.subscribe(fn, topic=topic, options=options)
+            self.on('join', do_subscription)
+        return decorator
+
+    def register(self, uri, options=None):
+        """
+        A decorator as a shortcut for registering during on-join
+
+        For example::
+
+            @component.register(
+                u"com.example.add",
+                options=RegisterOptions(invoke='round_robin'),
+            )
+            def add(*args, **kw):
+                print("add({}, {}): event received".format(args, kw))
+        """
+        assert options is None or isinstance(options, types.RegisterOptions)
+
+        def decorator(fn):
+
+            def do_registration(session, details):
+                return session.register(fn, procedure=uri, options=options)
+            self.on('join', do_registration)
+        return decorator
+
     def __init__(self, main=None, transports=None, config=None, realm=u'default', extra=None):
         """
         :param main: After a transport has been connected and a session

--- a/autobahn/wamp/component.py
+++ b/autobahn/wamp/component.py
@@ -38,7 +38,7 @@ import txaio
 
 from autobahn.util import ObservableMixin
 from autobahn.websocket.util import parse_url
-from autobahn.wamp.types import ComponentConfig
+from autobahn.wamp.types import ComponentConfig, SubscribeOptions, RegisterOptions
 from autobahn.wamp.exception import SessionNotReady
 
 
@@ -313,7 +313,7 @@ class Component(ObservableMixin):
             def topic(*args, **kw):
                 print("some.topic({}, {}): event received".format(args, kw))
         """
-        assert options is None or isinstance(options, types.SubscribeOptions)
+        assert options is None or isinstance(options, SubscribeOptions)
 
         def decorator(fn):
 
@@ -335,7 +335,7 @@ class Component(ObservableMixin):
             def add(*args, **kw):
                 print("add({}, {}): event received".format(args, kw))
         """
-        assert options is None or isinstance(options, types.RegisterOptions)
+        assert options is None or isinstance(options, RegisterOptions)
 
         def decorator(fn):
 


### PR DESCRIPTION
This is a decorator-based API for components to subscribe and register functions. This lets you do things like this:

```python
component = Component(...)

@component.subscribe(
    u"com.example.",
    options=SubscribeOptions(match=u"prefix", details_arg='details'),
)
def an_event(details=None):
    print("topic '{}'".format(details.topic))
```

**However**, this doesn't have a good story for "how do I get crossbar to run it".

One option could be config-parsing so that you can describe the topic + options.

Another option would be to define an `object` component in crossbar that is given a module to load and it looks for a "component" object which it uses to connect to crossbar. There would be a question here about what to do about the transports/connection information -- override whatever the component has with transports defined in the crossbar config, or accept what it has from code? Or it could just be an error if there's redundant transports.