### PR TITLE
experiment: authentication API

### DIFF
--- a/autobahn/twisted/wamp.py
+++ b/autobahn/twisted/wamp.py
@@ -34,7 +34,6 @@ import txaio
 txaio.use_twisted()  # noqa
 
 from twisted.internet.defer import inlineCallbacks, succeed
-from zope.interface import Interface, implementer
 
 from autobahn.util import public
 
@@ -47,9 +46,9 @@ from autobahn.twisted.rawsocket import WampRawSocketClientFactory
 from autobahn.websocket.compress import PerMessageDeflateOffer, \
     PerMessageDeflateResponse, PerMessageDeflateResponseAccept
 
-from autobahn.wamp import protocol
+from autobahn.wamp import protocol, auth
+from autobahn.wamp.interfaces import IAuthenticator
 from autobahn.wamp.types import ComponentConfig
-from autobahn.wamp import auth
 
 
 __all__ = [
@@ -860,14 +859,6 @@ class Session(ApplicationSession):
 
 
 # experimental authentication API
-class IAuthenticator(Interface):
-
-    def on_challenge(session, challenge):
-        """
-        """
-
-
-@implementer(IAuthenticator)
 class AuthCryptoSign(object):
 
     def __init__(self, **kw):
@@ -906,9 +897,9 @@ class AuthCryptoSign(object):
 
     def on_challenge(self, session, challenge):
         return self._privkey.sign_challenge(session, challenge)
+IAuthenticator.register(AuthCryptoSign)
 
 
-@implementer(IAuthenticator)
 class AuthWampCra(object):
 
     def __init__(self, **kw):
@@ -935,4 +926,4 @@ class AuthWampCra(object):
             challenge.extra['challenge'].encode('utf8')
         )
         return signature.decode('ascii')
-
+IAuthenticator.register(AuthWampCra)

--- a/autobahn/twisted/wamp.py
+++ b/autobahn/twisted/wamp.py
@@ -897,6 +897,8 @@ class AuthCryptoSign(object):
 
     def on_challenge(self, session, challenge):
         return self._privkey.sign_challenge(session, challenge)
+
+
 IAuthenticator.register(AuthCryptoSign)
 
 
@@ -918,7 +920,7 @@ class AuthWampCra(object):
         self._args = kw
         self._secret = kw.pop(u'secret')
         if not isinstance(self._secret, six.text_type):
-            challenge = self._secret.decode('utf8')
+            self._secret = self._secret.decode('utf8')
 
     def on_challenge(self, session, challenge):
         signature = auth.compute_wcs(
@@ -926,4 +928,6 @@ class AuthWampCra(object):
             challenge.extra['challenge'].encode('utf8')
         )
         return signature.decode('ascii')
+
+
 IAuthenticator.register(AuthWampCra)

--- a/autobahn/wamp/component.py
+++ b/autobahn/wamp/component.py
@@ -382,7 +382,7 @@ class Component(ObservableMixin):
         :type realm: unicode
 
         :param authentication: configuration of authenticators
-        :type authentication: dict or list of dicts
+        :type authentication: dict mapping auth_type to dict
         """
         self.set_valid_events(
             [

--- a/autobahn/wamp/component.py
+++ b/autobahn/wamp/component.py
@@ -430,7 +430,7 @@ class Component(ObservableMixin):
             )
 
         # XXX should have some checkconfig support
-        self._authentication = authentication or []
+        self._authentication = authentication or {}
 
         self._realm = realm
         self._extra = extra

--- a/autobahn/wamp/component.py
+++ b/autobahn/wamp/component.py
@@ -344,7 +344,7 @@ class Component(ObservableMixin):
             self.on('join', do_registration)
         return decorator
 
-    def __init__(self, main=None, transports=None, config=None, realm=u'default', extra=None):
+    def __init__(self, main=None, transports=None, config=None, realm=u'default', extra=None, authentication=None):
         """
         :param main: After a transport has been connected and a session
             has been established and joined to a realm, this (async)
@@ -380,6 +380,9 @@ class Component(ObservableMixin):
 
         :param realm: the realm to join
         :type realm: unicode
+
+        :param authentication: configuration of authenticators
+        :type authentication: dict or list of dicts
         """
         self.set_valid_events(
             [
@@ -426,6 +429,9 @@ class Component(ObservableMixin):
                 _create_transport(idx, transport, self._check_native_endpoint)
             )
 
+        # XXX should have some checkconfig support
+        self._authentication = authentication or []
+
         self._realm = realm
         self._extra = extra
 
@@ -458,6 +464,9 @@ class Component(ObservableMixin):
             cfg = ComponentConfig(self._realm, self._extra)
             try:
                 session = self.session_factory(cfg)
+                for auth_name, auth_config in self._authentication.items():
+                    session.add_authenticator(auth_name, **auth_config)
+
             except Exception as e:
                 # couldn't instantiate session calls, which is fatal.
                 # let the reconnection logic deal with that

--- a/autobahn/wamp/cryptosign.py
+++ b/autobahn/wamp/cryptosign.py
@@ -497,6 +497,17 @@ if HAS_CRYPTOSIGN:
 
         @util.public
         @classmethod
+        def from_key_bytes(cls, keydata, comment=None):
+            if not (comment is None or type(comment) == six.text_type):
+                raise ValueError("invalid type {} for comment".format(type(comment)))
+
+            if len(keydata) != 32:
+                raise ValueError("invalid key length {}".format(len(keydata)))
+
+            key = signing.SigningKey(keydata)
+            return cls(key, comment)
+
+        @classmethod
         def from_raw_key(cls, filename, comment=None):
             """
             Load an Ed25519 (private) signing key (actually, the seed for the key) from a raw file of 32 bytes length.
@@ -522,11 +533,7 @@ if HAS_CRYPTOSIGN:
             with open(filename, 'rb') as f:
                 keydata = f.read()
 
-            if len(keydata) != 32:
-                raise Exception("invalid key length {}".format(len(keydata)))
-
-            key = signing.SigningKey(keydata)
-            return cls(key, comment)
+            return cls.from_key_bytes(keydata, comment=comment)
 
         @util.public
         @classmethod

--- a/autobahn/wamp/interfaces.py
+++ b/autobahn/wamp/interfaces.py
@@ -637,3 +637,13 @@ class ISession(object):
         :returns: A single Deferred/Future or a list of such objects
         :rtype: instance(s) of :tx:`twisted.internet.defer.Deferred` / :py:class:`asyncio.Future`
         """
+
+
+# experimental authentication API
+@six.add_metaclass(abc.ABCMeta)
+class IAuthenticator(object):
+
+    @abc.abstractmethod
+    def on_challenge(session, challenge):
+        """
+        """

--- a/examples/router/.crossbar/config.json
+++ b/examples/router/.crossbar/config.json
@@ -116,6 +116,18 @@
                                 "anonymous": {
                                     "type": "static",
                                     "role": "anonymous"
+                                },
+                                "cryptosign": {
+                                    "type": "static",
+                                    "principals": {
+                                        "alice": {
+                                            "realm": "crossbardemo",
+                                            "role": "authenticated",
+                                            "authorized_keys": [
+                                                "020b13239ca0f10a1c65feaf26e8dfca6e84c81d2509a2b7b75a7e5ee5ce4b66"
+                                            ]
+                                        }
+                                    }
                                 }
                             }
                         }

--- a/examples/twisted/wamp/auth/backend.py
+++ b/examples/twisted/wamp/auth/backend.py
@@ -1,0 +1,56 @@
+###############################################################################
+#
+# The MIT License (MIT)
+#
+# Copyright (c) Crossbar.io Technologies GmbH
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+###############################################################################
+
+from os import environ
+from twisted.internet import reactor
+from twisted.internet.defer import inlineCallbacks
+
+from autobahn.twisted.wamp import Session, ApplicationRunner
+
+
+class Component(Session):
+    """
+    An application component calling the different backend procedures.
+    """
+
+    def onJoin(self, details):
+        print("session attached {}".format(details))
+        return self.leave()
+
+
+if __name__ == '__main__':
+    runner = ApplicationRunner(
+        environ.get("AUTOBAHN_DEMO_ROUTER", u"ws://127.0.0.1:8080/auth_ws"),
+        u"crossbardemo",
+    )
+
+    def make(config):
+        session = Component(config)
+        session.add_authenticator(
+            u"wampcra", authid=u'username', secret=u'p4ssw0rd'
+        )
+        return session
+    runner.run(make)

--- a/examples/twisted/wamp/auth/frontend.py
+++ b/examples/twisted/wamp/auth/frontend.py
@@ -1,0 +1,58 @@
+###############################################################################
+#
+# The MIT License (MIT)
+#
+# Copyright (c) Crossbar.io Technologies GmbH
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+###############################################################################
+
+from os import environ
+from twisted.internet import reactor
+from twisted.internet.defer import inlineCallbacks
+
+from autobahn.twisted.wamp import Session, ApplicationRunner
+
+
+class Component(Session):
+    """
+    An application component calling the different backend procedures.
+    """
+
+    def onJoin(self, details):
+        print("session attached {}".format(details))
+        return self.leave()
+
+
+if __name__ == '__main__':
+    runner = ApplicationRunner(
+        environ.get("AUTOBAHN_DEMO_ROUTER", u"ws://127.0.0.1:8080/auth_ws"),
+        u"crossbardemo",
+    )
+
+    def make(config):
+        session = Component(config)
+        session.add_authenticator(
+            u'cryptosign',
+            authid=u'alice',
+            privkey=u'6e3a302aa67d55ffc2059efeb5cf679470b37a26ae9ac18693b56ea3d0cd331c',
+        )
+        return session
+    runner.run(make)

--- a/examples/twisted/wamp/work/newapi/test_newapi_auth.py
+++ b/examples/twisted/wamp/work/newapi/test_newapi_auth.py
@@ -1,0 +1,34 @@
+from __future__ import print_function
+
+from autobahn.twisted.component import Component, run
+from autobahn.wamp import cryptosign
+import binascii
+
+privkey_hex = '6e3a302aa67d55ffc2059efeb5cf679470b37a26ae9ac18693b56ea3d0cd331c'
+# pubkey: 020b13239ca0f10a1c65feaf26e8dfca6e84c81d2509a2b7b75a7e5ee5ce4b66
+
+
+component = Component(
+    transports=u'ws://localhost:8080/auth_ws',
+    realm=u'crossbardemo',
+    authentication={
+        u"cryptosign": {
+            "authid": u"alice",
+            "privkey": privkey_hex,
+        }
+    }
+)
+
+
+@component.on_join
+def join(session, details):
+    print("Session {} joined: {}".format(details.session, details))
+
+
+@component.on_leave
+def leave(session, reason):
+    print("leaving", session, reason)
+
+
+if __name__ == '__main__':
+    run(component)

--- a/examples/twisted/wamp/work/newapi/test_newapi_cryptosign.py
+++ b/examples/twisted/wamp/work/newapi/test_newapi_cryptosign.py
@@ -25,10 +25,5 @@ def join(session, details):
     print("Session {} joined: {}".format(details.session, details))
 
 
-@component.on_leave
-def leave(session, reason):
-    print("leaving", session, reason)
-
-
 if __name__ == '__main__':
     run(component)

--- a/examples/twisted/wamp/work/newapi/test_newapi_wampcra.py
+++ b/examples/twisted/wamp/work/newapi/test_newapi_wampcra.py
@@ -1,0 +1,29 @@
+from __future__ import print_function
+
+from autobahn.twisted.component import Component, run
+from autobahn.wamp import cryptosign
+import binascii
+
+privkey_hex = '6e3a302aa67d55ffc2059efeb5cf679470b37a26ae9ac18693b56ea3d0cd331c'
+# pubkey: 020b13239ca0f10a1c65feaf26e8dfca6e84c81d2509a2b7b75a7e5ee5ce4b66
+
+
+component = Component(
+    transports=u'ws://localhost:8080/auth_ws',
+    realm=u'crossbardemo',
+    authentication={
+        u"wampcra": {
+            "authid": u"username",
+            "secret": u"p4ssw0rd",
+        }
+    }
+)
+
+
+@component.on_join
+def join(session, details):
+    print("Session {} joined: {}".format(details.session, details))
+
+
+if __name__ == '__main__':
+    run(component)


### PR DESCRIPTION
This is an experiment with an authentication API for "new Session".

This means normal users wouldn't have to use onConnect or onChallenge at all -- they'd just pass configuration to Component (or use `.add_authenticator` if they got a `Session` instance somehow).

Any client-type connections that need authentication could be configured (in e.g. crossbar) with the same dicts that are given to "authentication=" list in `Component`.

This would need fleshing out to more authentication types and moving / improving the validation code to checkconfig etc.