### PR TITLE
Async request errbacks

### DIFF
--- a/autobahn/wamp/protocol.py
+++ b/autobahn/wamp/protocol.py
@@ -1131,10 +1131,11 @@ class ApplicationSession(BaseSession):
             outstanding.extend(requests.values())
             requests.clear()
 
-        self.log.info(
-            'Cancelling {count} outstanding requests',
-            count=len(outstanding),
-        )
+        if outstanding:
+            self.log.info(
+                'Cancelling {count} outstanding requests',
+                count=len(outstanding),
+            )
         for request in outstanding:
             self.log.debug(
                 'cleaning up outstanding {request_type} request {request_id}, '


### PR DESCRIPTION
Follow-up to: https://github.com/crossbario/autobahn-python/commit/a65a7e480e2b6bf43056c27bb7573c766ae99dcb#commitcomment-21528112

This adds some unit-tests, refactors the method so we only `info` log once and handles async errbacks properly. I think ;)