### PR TITLE
Register/Subscribe Decorator Improvements

### DIFF
--- a/autobahn/wamp/test/test_uri_pattern.py
+++ b/autobahn/wamp/test/test_uri_pattern.py
@@ -27,7 +27,7 @@
 from __future__ import absolute_import
 
 from autobahn import wamp
-from autobahn.wamp.uri import Pattern
+from autobahn.wamp.uri import Pattern, RegisterOptions, SubscribeOptions
 
 import unittest2 as unittest
 
@@ -141,6 +141,24 @@ class TestDecorators(unittest.TestCase):
         self.assertEqual(update._wampuris[0].uri(), u"com.myapp.<category:string>.<cid:int>.update")
         self.assertEqual(update._wampuris[0]._type, Pattern.URI_TYPE_WILDCARD)
 
+        @wamp.register(u"com.myapp.circle.<name:string>",
+                       RegisterOptions(match=u"wildcard", details_arg="details"))
+        def circle(name=None, details=None):
+            """ Do nothing. """
+
+        self.assertTrue(hasattr(circle, '_wampuris'))
+        self.assertTrue(type(circle._wampuris) == list)
+        self.assertEqual(len(circle._wampuris), 1)
+        self.assertIsInstance(circle._wampuris[0], Pattern)
+        self.assertIsInstance(circle._wampuris[0].options, RegisterOptions)
+        self.assertEqual(circle._wampuris[0].options.match, u"wildcard")
+        self.assertEqual(circle._wampuris[0].options.details_arg, "details")
+        self.assertTrue(circle._wampuris[0].is_endpoint())
+        self.assertFalse(circle._wampuris[0].is_handler())
+        self.assertFalse(circle._wampuris[0].is_exception())
+        self.assertEqual(circle._wampuris[0].uri(), u"com.myapp.circle.<name:string>")
+        self.assertEqual(circle._wampuris[0]._type, Pattern.URI_TYPE_WILDCARD)
+
     def test_decorate_handler(self):
 
         @wamp.subscribe(u"com.myapp.on_shutdown")
@@ -184,6 +202,24 @@ class TestDecorators(unittest.TestCase):
         self.assertFalse(on_update._wampuris[0].is_exception())
         self.assertEqual(on_update._wampuris[0].uri(), u"com.myapp.<category:string>.<cid:int>.on_update")
         self.assertEqual(on_update._wampuris[0]._type, Pattern.URI_TYPE_WILDCARD)
+
+        @wamp.subscribe(u"com.myapp.on.<event:string>",
+                        SubscribeOptions(match=u"wildcard", details_arg="details"))
+        def on_event(event=None, details=None):
+            """ Do nothing. """
+
+        self.assertTrue(hasattr(on_event, '_wampuris'))
+        self.assertTrue(type(on_event._wampuris) == list)
+        self.assertEqual(len(on_event._wampuris), 1)
+        self.assertIsInstance(on_event._wampuris[0], Pattern)
+        self.assertIsInstance(on_event._wampuris[0].options, SubscribeOptions)
+        self.assertEqual(on_event._wampuris[0].options.match, u"wildcard")
+        self.assertEqual(on_event._wampuris[0].options.details_arg, "details")
+        self.assertFalse(on_event._wampuris[0].is_endpoint())
+        self.assertTrue(on_event._wampuris[0].is_handler())
+        self.assertFalse(on_event._wampuris[0].is_exception())
+        self.assertEqual(on_event._wampuris[0].uri(), u"com.myapp.on.<event:string>")
+        self.assertEqual(on_event._wampuris[0]._type, Pattern.URI_TYPE_WILDCARD)
 
     def test_decorate_exception(self):
 

--- a/autobahn/wamp/uri.py
+++ b/autobahn/wamp/uri.py
@@ -142,7 +142,7 @@ class Pattern(object):
         :param target: The target for this pattern: a procedure endpoint (a callable),
            an event handler (a callable) or an exception (a class).
         :type target: callable or obj
-        
+
         :param options: An optional options object
         :type options: None or RegisterOptions or SubscribeOptions
         """
@@ -224,7 +224,7 @@ class Pattern(object):
     def options(self):
         """
         Returns the Options instance (if present) for this pattern.
-        
+
         :return: None or the Options instance
         :rtype: None or RegisterOptions or SubscribeOptions
         """
@@ -235,8 +235,8 @@ class Pattern(object):
     def uri_type(self):
         """
         Returns the URI type of this pattern
-        
-        :return: 
+
+        :return:
         :rtype: Pattern.URI_TYPE_EXACT, Pattern.URI_TYPE_PREFIX or Pattern.URI_TYPE_WILDCARD
         """
         return self._type
@@ -312,10 +312,10 @@ class Pattern(object):
 def register(uri, options=None):
     """
     Decorator for WAMP procedure endpoints.
-    
+
     :param uri:
     :type uri: str
-    
+
     :param options:
     :type options: None or RegisterOptions
     """
@@ -332,10 +332,10 @@ def register(uri, options=None):
 def subscribe(uri, options=None):
     """
     Decorator for WAMP event handlers.
-    
+
     :param uri:
     :type uri: str
-    
+
     :param options:
     :type options: None or SubscribeOptions
     """

--- a/autobahn/wamp/uri.py
+++ b/autobahn/wamp/uri.py
@@ -231,6 +231,17 @@ class Pattern(object):
         return self._options
 
     @public
+    @property
+    def uri_type(self):
+        """
+        Returns the URI type of this pattern
+        
+        :return: 
+        :rtype: Pattern.URI_TYPE_EXACT, Pattern.URI_TYPE_PREFIX or Pattern.URI_TYPE_WILDCARD
+        """
+        return self._type
+
+    @public
     def uri(self):
         """
         Returns the original URI (pattern) for this pattern.
@@ -239,12 +250,6 @@ class Pattern(object):
         :rtype: str
         """
         return self._uri
-
-    def subscribe_options(self):
-        if self._type == Pattern.URI_TYPE_WILDCARD:
-            return SubscribeOptions(match=u"wildcard")
-        else:
-            return SubscribeOptions(match=u"exact")
 
     def match(self, uri):
         """

--- a/autobahn/wamp/uri.py
+++ b/autobahn/wamp/uri.py
@@ -28,6 +28,7 @@
 from __future__ import absolute_import
 
 import re
+
 import six
 
 from autobahn.util import public
@@ -282,7 +283,7 @@ class Pattern(object):
 
 
 @public
-def register(uri):
+def register(uri, **options):
     """
     Decorator for WAMP procedure endpoints.
     """
@@ -290,13 +291,16 @@ def register(uri):
         assert(callable(f))
         if not hasattr(f, '_wampuris'):
             f._wampuris = []
-        f._wampuris.append(Pattern(uri, Pattern.URI_TARGET_ENDPOINT))
+        f._wampuris.append((
+            Pattern(uri, Pattern.URI_TARGET_ENDPOINT),
+            options if options else None
+        ))
         return f
     return decorate
 
 
 @public
-def subscribe(uri):
+def subscribe(uri, **options):
     """
     Decorator for WAMP event handlers.
     """
@@ -304,7 +308,10 @@ def subscribe(uri):
         assert(callable(f))
         if not hasattr(f, '_wampuris'):
             f._wampuris = []
-        f._wampuris.append(Pattern(uri, Pattern.URI_TARGET_HANDLER))
+        f._wampuris.append((
+            Pattern(uri, Pattern.URI_TARGET_HANDLER),
+            options if options else None
+        ))
         return f
     return decorate
 


### PR DESCRIPTION
A small improvement which allows kwargs to be passed in to the register/subscribe decorators which allows for construction of RegisterOptions  and SubscriveOptions in ApplicationSession.register and ApplicationSession.subscribe