### PR TITLE
Added support for the X-Forwarded-For HTTP header

### DIFF
--- a/autobahn/websocket/interfaces.py
+++ b/autobahn/websocket/interfaces.py
@@ -126,7 +126,8 @@ class IWebSocketServerChannelFactory(object):
                            flashSocketPolicy=None,
                            allowedOrigins=None,
                            allowNullOrigin=False,
-                           maxConnections=None):
+                           maxConnections=None,
+                           trustXForwardedFor=0):
         """
         Set WebSocket protocol options used as defaults for new protocol instances.
 
@@ -201,6 +202,9 @@ class IWebSocketServerChannelFactory(object):
 
         :param maxConnections: Maximum number of concurrent connections. Set to `0` to disable (default: `0`).
         :type maxConnections: int or None
+
+        :param trustXForwardedFor: Number of trusted web servers in front of this server that add their own X-Forwarded-For header (default: `0`)
+        :type trustXForwardedFor: int
         """
 
     @public

--- a/docs/websocket/programming.rst
+++ b/docs/websocket/programming.rst
@@ -529,6 +529,7 @@ Server-Only Options
 - flashSocketPolicy: the actual flash policy to serve (default one allows everything)
 - allowedOrigins: a list of origins to allow, with embedded `*`'s for wildcards; these are turned into regular expressions (e.g. `https://*.example.com:443` becomes `^https://.*\.example\.com:443$`). When doing the matching, the origin is **always** of the form `scheme://host:port` with an explicit port. By default, we match with `*` (that is, anything). To match all subdomains of `example.com` on any scheme and port, you'd need `*://*.example.com:*`
 - maxConnections: total concurrent connections allowed (default 0, unlimited)
+- trustXForwardedFor: number of trusted web servers (reverse proxies) in front of this server which set the X-Forwarded-For header
 
 
 Client-Only Options


### PR DESCRIPTION
When the websocket server is sitting in front of one or more front end web servers, this allows the real client from the X-Forwarded-For header to be used as the peer address.