### PR TITLE
Ensuring drop reason always gets propogated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ node.key
 /.pydevproject
 /.venv/
 /my_tests/
+*.swp
+*.swo
+*.swn

--- a/autobahn/websocket/protocol.py
+++ b/autobahn/websocket/protocol.py
@@ -868,7 +868,7 @@ class WebSocketProtocol(object):
             if self.failByDrop:
                 # brutally drop the TCP connection
                 self.wasClean = False
-                self.wasNotCleanReason = u'I failed the WebSocket connection by dropping the TCP connection'
+                self.wasNotCleanReason = u'I dropped the WebSocket TCP connection: {0}'.format(reason)
                 self.dropConnection(abort=True)
 
             else:


### PR DESCRIPTION
This `reason` message contains important debugging information and should be made available when needed.