### PR TITLE
#836: register/subscribe decorators support different URI syntax from what session.register and session.subscribe support

### DIFF
--- a/autobahn/wamp/test/test_uri_pattern.py
+++ b/autobahn/wamp/test/test_uri_pattern.py
@@ -49,6 +49,7 @@ class TestUris(unittest.TestCase):
                   u"123",
                   u"com.myapp.<product:int>.update",
                   u"com.myapp.<category:string>.<subcategory>.list"
+                  u"com.myapp..update"
                   ]:
             p = Pattern(u, Pattern.URI_TARGET_ENDPOINT)
             self.assertIsInstance(p, Pattern)

--- a/autobahn/wamp/test/test_uri_pattern.py
+++ b/autobahn/wamp/test/test_uri_pattern.py
@@ -49,7 +49,7 @@ class TestUris(unittest.TestCase):
                   u"123",
                   u"com.myapp.<product:int>.update",
                   u"com.myapp.<category:string>.<subcategory>.list"
-                  u"com.myapp..update"
+                  u"com.myapp.something..update"
                   ]:
             p = Pattern(u, Pattern.URI_TARGET_ENDPOINT)
             self.assertIsInstance(p, Pattern)
@@ -159,6 +159,23 @@ class TestDecorators(unittest.TestCase):
         self.assertFalse(circle._wampuris[0].is_exception())
         self.assertEqual(circle._wampuris[0].uri(), u"com.myapp.circle.<name:string>")
         self.assertEqual(circle._wampuris[0]._type, Pattern.URI_TYPE_WILDCARD)
+
+        @wamp.register(u"com.myapp.something..update",
+                       RegisterOptions(match=u"wildcard", details_arg="details"))
+        def something(dynamic=None, details=None):
+            """ Do nothing. """
+        self.assertTrue(hasattr(something, '_wampuris'))
+        self.assertTrue(type(something._wampuris) == list)
+        self.assertEqual(len(something._wampuris), 1)
+        self.assertIsInstance(something._wampuris[0], Pattern)
+        self.assertIsInstance(something._wampuris[0].options, RegisterOptions)
+        self.assertEqual(something._wampuris[0].options.match, u"wildcard")
+        self.assertEqual(something._wampuris[0].options.details_arg, "details")
+        self.assertTrue(something._wampuris[0].is_endpoint())
+        self.assertFalse(something._wampuris[0].is_handler())
+        self.assertFalse(something._wampuris[0].is_exception())
+        self.assertEqual(something._wampuris[0].uri(), u"com.myapp.something..update")
+        self.assertEqual(something._wampuris[0]._type, Pattern.URI_TYPE_WILDCARD)
 
     def test_decorate_handler(self):
 

--- a/autobahn/wamp/uri.py
+++ b/autobahn/wamp/uri.py
@@ -147,6 +147,7 @@ class Pattern(object):
         :type options: None or RegisterOptions or SubscribeOptions
         """
         assert(type(uri) == six.text_type)
+        assert(len(uri) > 0)
         assert(target in [Pattern.URI_TARGET_ENDPOINT,
                           Pattern.URI_TARGET_HANDLER,
                           Pattern.URI_TARGET_EXCEPTION])

--- a/autobahn/wamp/uri.py
+++ b/autobahn/wamp/uri.py
@@ -160,6 +160,7 @@ class Pattern(object):
         components = uri.split('.')
         pl = []
         nc = {}
+        group_count = 0
         for i in range(len(components)):
             component = components[i]
 
@@ -185,6 +186,7 @@ class Pattern(object):
                     raise Exception("logic error")
 
                 pl.append("(?P<{0}>[a-z0-9_]+)".format(name))
+                group_count += 1
                 continue
 
             match = Pattern._URI_NAMED_COMPONENT.match(component)
@@ -195,11 +197,18 @@ class Pattern(object):
 
                 nc[name] = str
                 pl.append("(?P<{0}>[a-z0-9_]+)".format(name))
+                group_count += 1
                 continue
 
             match = Pattern._URI_COMPONENT.match(component)
             if match:
                 pl.append(component)
+                continue
+
+            if component == '':
+                group_count += 1
+                pl.append("([a-z0-9][a-z0-9_\-]*)")
+                nc[group_count] = str
                 continue
 
             raise Exception("invalid URI")


### PR DESCRIPTION
This is a simple fix for https://github.com/crossbario/autobahn-python/issues/836, which currently prevents the register/subscribe decorators from being used in conjunction with pattern-based registrations/subscriptions.

This fix is intended as a temporary measure until other changes are made to autobahn-python that will allow the named and/or typed wildcard component features of the `Pattern` class to function when used in conjunction with registrations and subscriptions.