### PR TITLE
Fix onConnect docstring regarding return value

### DIFF
--- a/autobahn/websocket/interfaces.py
+++ b/autobahn/websocket/interfaces.py
@@ -411,9 +411,9 @@ class IWebSocketChannel(object):
         :returns:
            When this callback is fired on a WebSocket server, you may return either ``None`` (in
            which case the connection is accepted with no specific WebSocket subprotocol) or
-           an instance of :class:`autobahn.websocket.types.ConnectionAccept`.
+           an str instance with the name of the WebSocket subprotocol accepted.
            When the callback is fired on a WebSocket client, this method must return ``None``.
-           Do deny a connection, raise an Exception.
+           To deny a connection, raise an Exception.
            You can also return a Deferred/Future that resolves/rejects to the above.
         """
 


### PR DESCRIPTION
The docstring mentioned a ConnectionAccept to be returned, whilst this model exists it doesn't seem to be used and the actual expected return value is str.