### PR TITLE
Newapi transport options

### DIFF
--- a/autobahn/twisted/component.py
+++ b/autobahn/twisted/component.py
@@ -150,7 +150,16 @@ def _create_transport_factory(reactor, transport, session_factory):
     if transport.type == 'websocket':
         # FIXME: forward WebSocket options
         serializers = _create_transport_serializers(transport)
-        return WampWebSocketClientFactory(session_factory, url=transport.url, serializers=serializers)
+        factory = WampWebSocketClientFactory(session_factory, url=transport.url, serializers=serializers)
+        # set the options one at a time so we can give user better feedback
+        for k, v in transport.options.items():
+            try:
+                factory.setProtocolOptions(**{k: v})
+            except (TypeError, KeyError) as e:
+                raise Exception(
+                    "Unknown transport option: {}={}".format(k, v)
+                )
+        return factory
 
     elif transport.type == 'rawsocket':
         # FIXME: forward RawSocket options

--- a/autobahn/twisted/component.py
+++ b/autobahn/twisted/component.py
@@ -143,8 +143,8 @@ def _create_transport_serializers(transport):
     return serializers
 
 
-def _camel_case_from_snake_case(s):
-    parts = s.split('_')
+def _camel_case_from_snake_case(snake):
+    parts = snake.split('_')
     return parts[0] + ''.join([s.capitalize() for s in parts[1:]])
 
 
@@ -175,7 +175,7 @@ def _create_transport_factory(reactor, transport, session_factory):
                 factory.setProtocolOptions(
                     **{_camel_case_from_snake_case(k): v}
                 )
-            except (TypeError, KeyError) as e:
+            except (TypeError, KeyError):
                 raise ValueError(
                     "Unknown {} transport option: {}={}".format(transport.type, k, v)
                 )

--- a/autobahn/twisted/component.py
+++ b/autobahn/twisted/component.py
@@ -157,7 +157,6 @@ def _create_transport_factory(reactor, transport, session_factory):
         factory = WampWebSocketClientFactory(session_factory, url=transport.url, serializers=serializers)
 
     elif transport.type == 'rawsocket':
-        # FIXME: forward RawSocket options
         serializer = _create_transport_serializer(transport.serializers[0])
         factory = WampRawSocketClientFactory(session_factory, serializer=serializer)
 

--- a/autobahn/wamp/component.py
+++ b/autobahn/wamp/component.py
@@ -116,7 +116,7 @@ def _create_transport(index, transport, check_native_endpoint=None):
     if type(transport) != dict:
         raise ValueError('invalid type {} for transport configuration - must be a dict'.format(type(transport)))
 
-    valid_transport_keys = ['type', 'url', 'endpoint', 'serializer', 'serializers']
+    valid_transport_keys = ['type', 'url', 'endpoint', 'serializer', 'serializers', 'options']
     for k in transport.keys():
         if k not in valid_transport_keys:
             raise ValueError(
@@ -130,6 +130,14 @@ def _create_transport(index, transport, check_native_endpoint=None):
         kind = transport['type']
     else:
         transport['type'] = 'websocket'
+
+    options = dict()
+    if 'options' in transport:
+        options = transport['options']
+        if not isinstance(options, dict):
+            raise ValueError(
+                'options must be a dict, not {}'.format(type(options))
+            )
 
     if kind == 'websocket':
         for key in ['url']:
@@ -200,6 +208,7 @@ def _create_transport(index, transport, check_native_endpoint=None):
         url=transport['url'],
         endpoint=endpoint_config,
         serializers=serializer_config,
+        options=options,
         **kw
     )
 
@@ -214,7 +223,8 @@ class _Transport(object):
                  max_retry_delay=300,
                  initial_retry_delay=1.5,
                  retry_delay_growth=1.5,
-                 retry_delay_jitter=0.1):
+                 retry_delay_jitter=0.1,
+                 options=dict()):
         """
         """
         self.idx = idx
@@ -222,6 +232,7 @@ class _Transport(object):
         self.type = kind
         self.url = url
         self.endpoint = endpoint
+        self.options = options
 
         self.serializers = serializers
         if self.type == 'rawsocket' and len(serializers) != 1:


### PR DESCRIPTION
Inspired by #838 this enables passing transport options through from the `Component` configuration -- so e.g. you can set the websocket open-handshake timeout in the Component's transport configuration and it'll get passed through.

I also added some code that allows us to document options as `snake_case` and it auto-translates it to `camelCase` and tries again before reporting an error (i.e. until the options themselves are turned into snake_case). If this latter isn't the plan I can take out this commit...