### PR TITLE
Examples js

### DIFF
--- a/examples/router/README
+++ b/examples/router/README
@@ -1,3 +1,9 @@
 This contains a configuration file in `.crossbar/config.json` to run a local Crossbar instance and serve some of the example content via a Web server.
 
 See [../running-the-examples.md] for more information.
+
+If you get 404 errors on autobahn.min.jgz do this:
+
+   curl --location -o ../autobahn.min.js https://github.com/crossbario/crossbar/raw/master/crossbar/templates/default/web/js/autobahn.min.js
+
+...to get the latest autobahn release in the "examples/" directory.

--- a/examples/running-the-examples.md
+++ b/examples/running-the-examples.md
@@ -53,6 +53,12 @@ Some **things to try**: open a new terminal and run a second frontend;  leave th
 
 If you want to use your own local [Crossbar](http://crossbar.io) instance you must have a Python2-based virtualenv and `pip install crossbar` in it. See also [crossbar.io's platform-specific installation instructions](http://crossbar.io/docs/Local-Installation/) as you may need to install some native libraries as well.
 
+Your crossbar instance will serve the [Autobahn JS](http://autobahn.ws/js) code to browser clients. To easily download a recent release, run the following in the `./examples` directory:
+
+```shell
+curl --location -O https://github.com/crossbario/crossbar/raw/master/crossbar/templates/default/web/js/autobahn.min.js
+```
+
 Once you have crossbar installed, use the provided router configuration in `examples/router/.crossbar/config.json`. Starting your router is then:
 
 ```shell
@@ -60,7 +66,9 @@ cd ./examples/router
 crossbar start
 ```
 
-There should now be a router listening on `localhost:8080` so you can change the URI in all the demos to `ws://localhost:8080/ws` or set the environment variable `AUTOBAHN_DEMO_ROUTER=ws://localhost:8080/ws` Obviously, this environment variable isn't used by in-browser JavaScript so you'll have to change .js files by hand.
+There should now be a router listening on `localhost:8080`.
+
+By default all the examples are set up to run against this address. You may set the environment variable `AUTOBAHN_DEMO_ROUTER=ws://localhost:8080/ws` if you configured yours differently from the defaults. Obviously, this environment variable isn't used by in-browser JavaScript so you'll have to change .js files by hand.
 
 If you are running the router successfully, you should see a Crossbar page at `http://localhost:8080/`. We've added enough configuration to serve the HTML, JavaScript and README files from all the examples; you should see a list of links at the page.
 

--- a/examples/twisted/wamp/app/calculator/index.html
+++ b/examples/twisted/wamp/app/calculator/index.html
@@ -35,7 +35,7 @@
       </style>
 
       <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
-      <script src="https://autobahn.s3.amazonaws.com/autobahnjs/latest/autobahn.min.jgz"></script>
+      <script src="/autobahn.min.js"></script>
 
       <script type="text/javascript">
 

--- a/examples/twisted/wamp/app/crochet/example1/client.html
+++ b/examples/twisted/wamp/app/crochet/example1/client.html
@@ -3,7 +3,7 @@
    <body>
       <h1>Flask/Crochet/Autobahn: Example 1</h1>
       <p>Open JavaScript console to watch output.</p>
-      <script src="https://autobahn.s3.amazonaws.com/autobahnjs/latest/autobahn.min.jgz"></script>
+      <script src="/autobahn.min.js"></script>
       <script>
          var connection = new autobahn.Connection({
             url: "ws://127.0.0.1:8080/ws",

--- a/examples/twisted/wamp/app/crochet/example2/test_wamp.html
+++ b/examples/twisted/wamp/app/crochet/example2/test_wamp.html
@@ -3,7 +3,7 @@
    <body>
       <h1>Flask/Crochet/Autobahn: Example 2 (WAMP Client)</h1>
       <p>Open JavaScript console to watch output.</p>
-      <script src="https://autobahn.s3.amazonaws.com/autobahnjs/latest/autobahn.min.jgz"></script>
+      <script src="/autobahn.min.js"></script>
       <script>
          var connection = new autobahn.Connection({
             url: "ws://127.0.0.1:9000",

--- a/examples/twisted/wamp/app/dbus/index.html
+++ b/examples/twisted/wamp/app/dbus/index.html
@@ -12,7 +12,7 @@
       </form>
       <button onclick="sendNotification();">Send Notification!</button>
 
-      <script src="https://autobahn.s3.amazonaws.com/autobahnjs/latest/autobahn.min.jgz"></script>
+      <script src="/autobahn.min.js"></script>
       <script>
 
          var session = null;

--- a/examples/twisted/wamp/app/hello/hello.html
+++ b/examples/twisted/wamp/app/hello/hello.html
@@ -4,7 +4,7 @@
       <h1>Hello WAMP</h1>
       <p>Open JavaScript console to watch output.</p>
 
-      <script src="https://autobahn.s3.amazonaws.com/autobahnjs/latest/autobahn.min.jgz"></script>
+      <script src="/autobahn.min.js"></script>
       <script>
          var connection = new autobahn.Connection({
             url: "ws://127.0.0.1:8080/ws",

--- a/examples/twisted/wamp/app/keyvalue/index.html
+++ b/examples/twisted/wamp/app/keyvalue/index.html
@@ -31,7 +31,7 @@
       </div>
       <pre id="log" style="height: 20em; overflow-y: scroll; background-color: #faa;"></pre>
 
-      <script src="https://autobahn.s3.amazonaws.com/autobahnjs/latest/autobahn.min.jgz"></script>
+      <script src="/autobahn.min.js"></script>
 
       <script type="text/javascript">
          var session = null;

--- a/examples/twisted/wamp/app/klein/example1/test_wamp.html
+++ b/examples/twisted/wamp/app/klein/example1/test_wamp.html
@@ -3,7 +3,7 @@
    <body>
       <h1>Hello WAMP</h1>
       <p>Open JavaScript console to watch output.</p>
-      <script src="https://autobahn.s3.amazonaws.com/autobahnjs/latest/autobahn.min.jgz"></script>
+      <script src="/autobahn.min.js"></script>
       <script>
          var connection = new autobahn.Connection({
             url: "ws://127.0.0.1:9000",

--- a/examples/twisted/wamp/app/klein/example2/templates/index.html
+++ b/examples/twisted/wamp/app/klein/example2/templates/index.html
@@ -27,7 +27,7 @@
    </p>
 </form>
 
-<script src="https://autobahn.s3.amazonaws.com/autobahnjs/latest/autobahn.min.jgz"></script>
+<script src="/autobahn.min.js"></script>
 <script>
    var connection = new autobahn.Connection({
       url: "ws://127.0.0.1:9000",

--- a/examples/twisted/wamp/app/serial2ws/index.html
+++ b/examples/twisted/wamp/app/serial2ws/index.html
@@ -1,7 +1,7 @@
  <html>
    <head>
       <title>Autobahn Serial2Ws</title>
-      <script src="https://autobahn.s3.amazonaws.com/autobahnjs/latest/autobahn.min.jgz"></script>
+      <script src="/autobahn.min.js"></script>
       <script src="smoothie.js"></script>
 
       <script>

--- a/examples/twisted/wamp/app/subscribe_upon_call/subscribe_upon_call.html
+++ b/examples/twisted/wamp/app/subscribe_upon_call/subscribe_upon_call.html
@@ -3,7 +3,7 @@
    <body>
       <h1>Subscribe upon Call</h1>
       <p>Open JavaScript console to watch output.</p>
-      <script src="https://autobahn.s3.amazonaws.com/autobahnjs/latest/autobahn.min.jgz"></script>
+      <script src="/autobahn.min.js"></script>
 
       <button onclick="do_call()">Call Backend, triggering subscribe</button>
 

--- a/examples/twisted/wamp/pubsub/basic/backend.html
+++ b/examples/twisted/wamp/pubsub/basic/backend.html
@@ -3,7 +3,7 @@
    <body>
       <h1>PubSub Basic Backend</h1>
       <p>Open JavaScript console to watch output.</p>
-      <script src="https://autobahn.s3.amazonaws.com/autobahnjs/latest/autobahn.min.jgz"></script>
+      <script src="/autobahn.min.js"></script>
       <script src="backend.js"></script>
    </body>
 </html>

--- a/examples/twisted/wamp/pubsub/basic/frontend.html
+++ b/examples/twisted/wamp/pubsub/basic/frontend.html
@@ -3,7 +3,7 @@
    <body>
       <h1>PubSub Basic Frontend</h1>
       <p>Open JavaScript console to watch output.</p>
-      <script src="https://autobahn.s3.amazonaws.com/autobahnjs/latest/autobahn.min.jgz"></script>
+      <script src="/autobahn.min.js"></script>
       <script src="frontend.js"></script>
    </body>
 </html>

--- a/examples/twisted/wamp/pubsub/complex/backend.html
+++ b/examples/twisted/wamp/pubsub/complex/backend.html
@@ -3,7 +3,7 @@
    <body>
       <h1>PubSub Complex Event Backend</h1>
       <p>Open JavaScript console to watch output.</p>
-      <script src="https://autobahn.s3.amazonaws.com/autobahnjs/latest/autobahn.min.jgz"></script>
+      <script src="/autobahn.min.js"></script>
       <script src="backend.js"></script>
    </body>
 </html>

--- a/examples/twisted/wamp/pubsub/complex/frontend.html
+++ b/examples/twisted/wamp/pubsub/complex/frontend.html
@@ -3,7 +3,7 @@
    <body>
       <h1>PubSub Complex Event Frontend</h1>
       <p>Open JavaScript console to watch output.</p>
-      <script src="https://autobahn.s3.amazonaws.com/autobahnjs/latest/autobahn.min.jgz"></script>
+      <script src="/autobahn.min.js"></script>
       <script src="frontend.js"></script>
    </body>
 </html>

--- a/examples/twisted/wamp/pubsub/decorators/backend.html
+++ b/examples/twisted/wamp/pubsub/decorators/backend.html
@@ -3,7 +3,7 @@
    <body>
       <h1>PubSub Decorators Backend</h1>
       <p>Open JavaScript console to watch output.</p>
-      <script src="https://autobahn.s3.amazonaws.com/autobahnjs/latest/autobahn.min.jgz"></script>
+      <script src="/autobahn.min.js"></script>
       <script src="backend.js"></script>
    </body>
 </html>

--- a/examples/twisted/wamp/pubsub/decorators/frontend.html
+++ b/examples/twisted/wamp/pubsub/decorators/frontend.html
@@ -3,7 +3,7 @@
    <body>
       <h1>PubSub Decorators Frontend</h1>
       <p>Open JavaScript console to watch output.</p>
-      <script src="https://autobahn.s3.amazonaws.com/autobahnjs/latest/autobahn.min.jgz"></script>
+      <script src="/autobahn.min.js"></script>
       <script src="frontend.js"></script>
    </body>
 </html>

--- a/examples/twisted/wamp/pubsub/options/backend.html
+++ b/examples/twisted/wamp/pubsub/options/backend.html
@@ -3,7 +3,7 @@
    <body>
       <h1>PubSub Options Backend</h1>
       <p>Open JavaScript console to watch output.</p>
-      <script src="https://autobahn.s3.amazonaws.com/autobahnjs/latest/autobahn.min.jgz"></script>
+      <script src="/autobahn.min.js"></script>
       <script src="backend.js"></script>
    </body>
 </html>

--- a/examples/twisted/wamp/pubsub/options/frontend.html
+++ b/examples/twisted/wamp/pubsub/options/frontend.html
@@ -3,7 +3,7 @@
    <body>
       <h1>PubSub Options Frontend</h1>
       <p>Open JavaScript console to watch output.</p>
-      <script src="https://autobahn.s3.amazonaws.com/autobahnjs/latest/autobahn.min.jgz"></script>
+      <script src="/autobahn.min.js"></script>
       <script src="frontend.js"></script>
    </body>
 </html>

--- a/examples/twisted/wamp/pubsub/unsubscribe/backend.html
+++ b/examples/twisted/wamp/pubsub/unsubscribe/backend.html
@@ -3,7 +3,7 @@
    <body>
       <h1>PubSub Unsubscribe Backend</h1>
       <p>Open JavaScript console to watch output.</p>
-      <script src="https://autobahn.s3.amazonaws.com/autobahnjs/latest/autobahn.min.jgz"></script>
+      <script src="/autobahn.min.js"></script>
       <script src="backend.js"></script>
    </body>
 </html>

--- a/examples/twisted/wamp/pubsub/unsubscribe/frontend.html
+++ b/examples/twisted/wamp/pubsub/unsubscribe/frontend.html
@@ -3,7 +3,7 @@
    <body>
       <h1>PubSub Unsubscribe Frontend</h1>
       <p>Open JavaScript console to watch output.</p>
-      <script src="https://autobahn.s3.amazonaws.com/autobahnjs/latest/autobahn.min.jgz"></script>
+      <script src="/autobahn.min.js"></script>
       <script src="frontend.js"></script>
    </body>
 </html>

--- a/examples/twisted/wamp/rpc/arguments/backend.html
+++ b/examples/twisted/wamp/rpc/arguments/backend.html
@@ -3,7 +3,7 @@
    <body>
       <h1>RPC Arguments Backend</h1>
       <p>Open JavaScript console to watch output.</p>
-      <script src="https://autobahn.s3.amazonaws.com/autobahnjs/latest/autobahn.min.jgz"></script>
+      <script src="/autobahn.min.js"></script>
       <script src="backend.js"></script>
    </body>
 </html>

--- a/examples/twisted/wamp/rpc/arguments/frontend.html
+++ b/examples/twisted/wamp/rpc/arguments/frontend.html
@@ -3,7 +3,7 @@
    <body>
       <h1>RPC Arguments Frontend</h1>
       <p>Open JavaScript console to watch output.</p>
-      <script src="https://autobahn.s3.amazonaws.com/autobahnjs/latest/autobahn.min.jgz"></script>
+      <script src="/autobahn.min.js"></script>
       <script src="frontend.js"></script>
    </body>
 </html>

--- a/examples/twisted/wamp/rpc/cancel/backend.html
+++ b/examples/twisted/wamp/rpc/cancel/backend.html
@@ -3,7 +3,7 @@
    <body>
       <h1>RPC Arguments Backend</h1>
       <p>Open JavaScript console to watch output.</p>
-      <script src="https://autobahn.s3.amazonaws.com/autobahnjs/latest/autobahn.min.jgz"></script>
+      <script src="/autobahn.min.js"></script>
       <script src="backend.js"></script>
    </body>
 </html>

--- a/examples/twisted/wamp/rpc/cancel/frontend.html
+++ b/examples/twisted/wamp/rpc/cancel/frontend.html
@@ -3,7 +3,7 @@
    <body>
       <h1>RPC Arguments Frontend</h1>
       <p>Open JavaScript console to watch output.</p>
-      <script src="https://autobahn.s3.amazonaws.com/autobahnjs/latest/autobahn.min.jgz"></script>
+      <script src="/autobahn.min.js"></script>
       <script src="frontend.js"></script>
    </body>
 </html>

--- a/examples/twisted/wamp/rpc/complex/backend.html
+++ b/examples/twisted/wamp/rpc/complex/backend.html
@@ -3,7 +3,7 @@
    <body>
       <h1>RPC Complex Result Backend</h1>
       <p>Open JavaScript console to watch output.</p>
-      <script src="https://autobahn.s3.amazonaws.com/autobahnjs/latest/autobahn.min.jgz"></script>
+      <script src="/autobahn.min.js"></script>
       <script src="backend.js"></script>
    </body>
 </html>

--- a/examples/twisted/wamp/rpc/complex/frontend.html
+++ b/examples/twisted/wamp/rpc/complex/frontend.html
@@ -3,7 +3,7 @@
    <body>
       <h1>RPC Complex Result Frontend</h1>
       <p>Open JavaScript console to watch output.</p>
-      <script src="https://autobahn.s3.amazonaws.com/autobahnjs/latest/autobahn.min.jgz"></script>
+      <script src="/autobahn.min.js"></script>
       <script src="frontend.js"></script>
    </body>
 </html>

--- a/examples/twisted/wamp/rpc/decorators/frontend.html
+++ b/examples/twisted/wamp/rpc/decorators/frontend.html
@@ -3,7 +3,7 @@
    <body>
       <h1>RPC Decorators Frontend</h1>
       <p>Open JavaScript console to watch output.</p>
-      <script src="https://autobahn.s3.amazonaws.com/autobahnjs/latest/autobahn.min.jgz"></script>
+      <script src="/autobahn.min.js"></script>
       <script src="frontend.js"></script>
    </body>
 </html>

--- a/examples/twisted/wamp/rpc/errors/backend.html
+++ b/examples/twisted/wamp/rpc/errors/backend.html
@@ -3,7 +3,7 @@
    <body>
       <h1>RPC Errors Backend</h1>
       <p>Open JavaScript console to watch output.</p>
-      <script src="https://autobahn.s3.amazonaws.com/autobahnjs/latest/autobahn.min.jgz"></script>
+      <script src="/autobahn.min.js"></script>
       <script src="backend.js"></script>
    </body>
 </html>

--- a/examples/twisted/wamp/rpc/errors/frontend.html
+++ b/examples/twisted/wamp/rpc/errors/frontend.html
@@ -3,7 +3,7 @@
    <body>
       <h1>RPC Errors Frontend</h1>
       <p>Open JavaScript console to watch output.</p>
-      <script src="https://autobahn.s3.amazonaws.com/autobahnjs/latest/autobahn.min.jgz"></script>
+      <script src="/autobahn.min.js"></script>
       <script src="frontend.js"></script>
    </body>
 </html>

--- a/examples/twisted/wamp/rpc/options/backend.html
+++ b/examples/twisted/wamp/rpc/options/backend.html
@@ -3,7 +3,7 @@
    <body>
       <h1>RPC Options Backend</h1>
       <p>Open JavaScript console to watch output.</p>
-      <script src="https://autobahn.s3.amazonaws.com/autobahnjs/latest/autobahn.min.jgz"></script>
+      <script src="/autobahn.min.js"></script>
       <script src="backend.js"></script>
    </body>
 </html>

--- a/examples/twisted/wamp/rpc/options/frontend.html
+++ b/examples/twisted/wamp/rpc/options/frontend.html
@@ -3,7 +3,7 @@
    <body>
       <h1>RPC Options Frontend</h1>
       <p>Open JavaScript console to watch output.</p>
-      <script src="https://autobahn.s3.amazonaws.com/autobahnjs/latest/autobahn.min.jgz"></script>
+      <script src="/autobahn.min.js"></script>
       <script src="frontend.js"></script>
    </body>
 </html>

--- a/examples/twisted/wamp/rpc/progress/backend.html
+++ b/examples/twisted/wamp/rpc/progress/backend.html
@@ -3,7 +3,7 @@
    <body>
       <h1>RPC Progressive Results Backend</h1>
       <p>Open JavaScript console to watch output.</p>
-      <script src="https://autobahn.s3.amazonaws.com/autobahnjs/latest/autobahn.min.jgz"></script>
+      <script src="/autobahn.min.js"></script>
       <script src="backend.js"></script>
    </body>
 </html>

--- a/examples/twisted/wamp/rpc/progress/frontend.html
+++ b/examples/twisted/wamp/rpc/progress/frontend.html
@@ -3,7 +3,7 @@
    <body>
       <h1>RPC Progressive Results Frontend</h1>
       <p>Open JavaScript console to watch output.</p>
-      <script src="https://autobahn.s3.amazonaws.com/autobahnjs/latest/autobahn.min.jgz"></script>
+      <script src="/autobahn.min.js"></script>
       <script src="frontend.js"></script>
    </body>
 </html>

--- a/examples/twisted/wamp/rpc/slowsquare/backend.html
+++ b/examples/twisted/wamp/rpc/slowsquare/backend.html
@@ -3,7 +3,7 @@
    <body>
       <h1>RPC Slow Square Backend</h1>
       <p>Open JavaScript console to watch output.</p>
-      <script src="https://autobahn.s3.amazonaws.com/autobahnjs/latest/autobahn.min.jgz"></script>
+      <script src="/autobahn.min.js"></script>
       <script src="backend.js"></script>
    </body>
 </html>

--- a/examples/twisted/wamp/rpc/slowsquare/frontend.html
+++ b/examples/twisted/wamp/rpc/slowsquare/frontend.html
@@ -3,7 +3,7 @@
    <body>
       <h1>RPC Slow Square Frontend</h1>
       <p>Open JavaScript console to watch output.</p>
-      <script src="https://autobahn.s3.amazonaws.com/autobahnjs/latest/autobahn.min.jgz"></script>
+      <script src="/autobahn.min.js"></script>
       <script src="frontend.js"></script>
    </body>
 </html>

--- a/examples/twisted/wamp/rpc/timeservice/backend.html
+++ b/examples/twisted/wamp/rpc/timeservice/backend.html
@@ -3,7 +3,7 @@
    <body>
       <h1>RPC Time Service Backend</h1>
       <p>Open JavaScript console to watch output.</p>
-      <script src="https://autobahn.s3.amazonaws.com/autobahnjs/latest/autobahn.min.jgz"></script>
+      <script src="/autobahn.min.js"></script>
       <script src="backend.js"></script>
    </body>
 </html>

--- a/examples/twisted/wamp/rpc/timeservice/frontend.html
+++ b/examples/twisted/wamp/rpc/timeservice/frontend.html
@@ -3,7 +3,7 @@
    <body>
       <h1>RPC Time Service Frontend</h1>
       <p>Open JavaScript console to watch output.</p>
-      <script src="https://autobahn.s3.amazonaws.com/autobahnjs/latest/autobahn.min.jgz"></script>
+      <script src="/autobahn.min.js"></script>
       <script src="frontend.js"></script>
    </body>
 </html>


### PR DESCRIPTION
point the examples at a locally-hosted autobahn.min.js and instructions to curl it from the crossbar github repo.