### PR TITLE
Asyncio component txaio

### DIFF
--- a/autobahn/asyncio/component.py
+++ b/autobahn/asyncio/component.py
@@ -368,6 +368,12 @@ class Component(component.Component):
                             self.log.error(u"{msg}", msg=fail.value.error_message())
                             return one_reconnect_loop(None)
 
+                        elif isinstance(fail.value, OSError):
+                            # failed to connect entirely, like nobody
+                            # listening etc.
+                            self.log.info(u"Connection failed: {msg}", msg=txaio.failure_message(fail))
+                            return one_reconnect_loop(None)
+
                         elif _is_ssl_error(fail.value):
                             # Quoting pyOpenSSL docs: "Whenever
                             # [SSL.Error] is raised directly, it has a

--- a/autobahn/asyncio/component.py
+++ b/autobahn/asyncio/component.py
@@ -395,6 +395,7 @@ class Component(component.Component):
                             # stacktraces logged immediately at error
                             # level, e.g. SyntaxError?
                             self.log.debug(u'{tb}', tb=txaio.failure_format_traceback(fail))
+                            return one_reconnect_loop(None)
 
                     txaio.add_callbacks(f, session_done, connect_error)
 

--- a/autobahn/asyncio/component.py
+++ b/autobahn/asyncio/component.py
@@ -354,7 +354,6 @@ class Component(component.Component):
                             txaio.reject(done_f, fail)
                             return
 
-                        transport.connect_failures += 1
                         self.log.debug(u'component failed: {error}', error=txaio.failure_message(fail))
                         self.log.debug(u'{tb}', tb=txaio.failure_format_traceback(fail))
                         # If this is a "fatal error" that will never work,

--- a/autobahn/twisted/component.py
+++ b/autobahn/twisted/component.py
@@ -368,11 +368,8 @@ class Component(component.Component):
                 )
                 yield sleep(delay)
                 try:
-                    transport.connect_attempts += 1
                     yield self._connect_once(reactor, transport)
-                    transport.connect_sucesses += 1
                 except Exception as e:
-                    transport.connect_failures += 1
                     f = txaio.create_failure()
                     self.log.error(u'component failed: {error}', error=txaio.failure_message(f))
                     self.log.debug(u'{tb}', tb=txaio.failure_format_traceback(f))

--- a/autobahn/wamp/component.py
+++ b/autobahn/wamp/component.py
@@ -510,6 +510,7 @@ class Component(ObservableMixin):
                 # it completely (i.e. until its Deferred fires) and
                 # then disconnect this session
                 def on_join(session, details):
+                    transport.connect_sucesses += 1
                     self.log.debug("session on_join: {details}", details=details)
                     d = txaio.as_future(self._entry, reactor, session)
 

--- a/autobahn/wamp/component.py
+++ b/autobahn/wamp/component.py
@@ -529,6 +529,7 @@ class Component(ObservableMixin):
                     def main_error(err):
                         self.log.debug("main_error: {err}", err=err)
                         txaio.reject(done, err)
+                        session.disconnect()
                     txaio.add_callbacks(d, main_success, main_error)
                 if self._entry is not None:
                     session.on('join', on_join)


### PR DESCRIPTION
Follow-up for https://github.com/crossbario/autobahn-python/pull/872 which re-writes the asyncio stuff using pure txaio (avoiding e.g. `yield from`).

Also fixes some statistics-counting and proper disconnect-on-error in the Twisted component as well.