### PR TITLE
Register prefix

### DIFF
--- a/autobahn/wamp/interfaces.py
+++ b/autobahn/wamp/interfaces.py
@@ -552,7 +552,7 @@ class ISession(object):
 
     @public
     @abc.abstractmethod
-    def register(self, endpoint, procedure=None, options=None):
+    def register(self, endpoint, procedure=None, options=None, prefix=None):
         """
         Register a procedure for remote calling.
 
@@ -581,6 +581,14 @@ class ISession(object):
 
         :param options: Options for registering.
         :type options: instance of :class:`autobahn.wamp.types.RegisterOptions`.
+
+
+        :param prefix: if not None, this specifies a prefix to prepend
+            to all URIs registered for this class. So if there was an
+            @wamp.register('method_foo') on a method and
+            prefix='com.something.' then a method
+            'com.something.method_foo' would ultimately be registered.
+        :type prefix: str
 
         :returns: A registration or a list of registrations (or errors)
         :rtype: instance(s) of :tx:`twisted.internet.defer.Deferred` / :py:class:`asyncio.Future`

--- a/autobahn/wamp/protocol.py
+++ b/autobahn/wamp/protocol.py
@@ -1453,13 +1453,14 @@ class ApplicationSession(BaseSession):
         return on_reply
 
     @public
-    def register(self, endpoint, procedure=None, options=None):
+    def register(self, endpoint, procedure=None, options=None, prefix=None):
         """
         Implements :func:`autobahn.wamp.interfaces.ICallee.register`
         """
         assert((callable(endpoint) and procedure is not None) or hasattr(endpoint, '__class__'))
         assert(procedure is None or type(procedure) == six.text_type)
         assert(options is None or isinstance(options, types.RegisterOptions))
+        assert prefix is None or isinstance(prefix, six.text_type)
 
         if not self._transport:
             raise exception.TransportLost()
@@ -1468,6 +1469,8 @@ class ApplicationSession(BaseSession):
             request_id = self._request_id_gen.next()
             on_reply = txaio.create_future()
             endpoint_obj = Endpoint(fn, obj, options.details_arg if options else None)
+            if prefix is not None:
+                procedure = u"{}{}".format(prefix, procedure)
             self._register_reqs[request_id] = RegisterRequest(request_id, on_reply, procedure, endpoint_obj)
 
             if options:

--- a/autobahn/wamp/protocol.py
+++ b/autobahn/wamp/protocol.py
@@ -67,6 +67,8 @@ class BaseSession(ObservableMixin):
     This class implements :class:`autobahn.wamp.interfaces.ISession`.
     """
 
+    log = txaio.make_logger()
+
     def __init__(self):
         """
 

--- a/autobahn/wamp/test/test_protocol.py
+++ b/autobahn/wamp/test/test_protocol.py
@@ -196,6 +196,25 @@ if os.environ.get('USE_TWISTED', False):
             reg = call.call_list()[0][1][0]
             self.assertEqual(u"com.example.prefix.method_name", reg.procedure)
 
+        def test_auto_name(self):
+
+            class Magic(ApplicationSession):
+
+                @uri.register(None)
+                def some_method(self):
+                    pass
+            session = Magic()
+
+            session._transport = mock.Mock()
+            session.register(session, prefix=u"com.example.")
+
+            # Should auto-discover name by passing uri=None above
+            self.assertEqual(1, len(session._transport.mock_calls))
+            call = session._transport.mock_calls[0]
+            self.assertEqual("send", call[0])
+            reg = call.call_list()[0][1][0]
+            self.assertEqual(u"com.example.some_method", reg.procedure)
+
     class TestPublisher(unittest.TestCase):
 
         @inlineCallbacks

--- a/autobahn/wamp/uri.py
+++ b/autobahn/wamp/uri.py
@@ -331,9 +331,16 @@ def register(uri, options=None):
     """
     def decorate(f):
         assert(callable(f))
+        if uri is None:
+            if six.PY2:
+                real_uri = u'{}'.format(f.func_name)
+            else:
+                real_uri = u'{}'.format(f.__name__)
+        else:
+            real_uri = uri
         if not hasattr(f, '_wampuris'):
             f._wampuris = []
-        f._wampuris.append(Pattern(uri, Pattern.URI_TARGET_ENDPOINT, options))
+        f._wampuris.append(Pattern(real_uri, Pattern.URI_TARGET_ENDPOINT, options))
         return f
     return decorate
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,7 @@ master
 **Not yet released**
 
 * new: prefix= kwarg now available on ApplicationSession.register for runtime method names
+* new: @wamp.register(None) will use the function-name as the URI
 
 
 17.7.1

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,13 @@
 Changelog
 =========
 
+master
+------
+
+**Not yet released**
+
+* new: prefix= kwarg now available on ApplicationSession.register for runtime method names
+
 
 17.7.1
 ------


### PR DESCRIPTION
This adds two new features to the `@wamp.register` decorator (and the related method that actually does the registrations):

 - adds a `prefix=` kwarg that is prepended to all registrations for an instance
 - allows passing `None` as the URI so the name is auto-discovered

Resulting code can look like:

```python
class Something(ApplicationSession):
    def onJoin(self, details):
        return self.register(self, prefix=u'com.example.')

    @wamp.register(None)
    def public_method(self):
        return 42
```

This will result in a method being registered at `com.example.public_method`