### PR TITLE
create new event loop if already closed

### DIFF
--- a/autobahn/asyncio/wamp.py
+++ b/autobahn/asyncio/wamp.py
@@ -246,8 +246,8 @@ class ApplicationRunner(object):
         # start the client connection
         loop = asyncio.get_event_loop()
         if loop.is_closed() and start_loop:
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
+            asyncio.set_event_loop(asyncio.new_event_loop())
+            loop = asyncio.get_event_loop()
         txaio.use_asyncio()
         txaio.config.loop = loop
         coro = loop.create_connection(transport_factory, host, port, ssl=ssl)

--- a/autobahn/asyncio/wamp.py
+++ b/autobahn/asyncio/wamp.py
@@ -245,6 +245,9 @@ class ApplicationRunner(object):
 
         # start the client connection
         loop = asyncio.get_event_loop()
+        if loop.is_closed() and start_loop:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
         txaio.use_asyncio()
         txaio.config.loop = loop
         coro = loop.create_connection(transport_factory, host, port, ssl=ssl)


### PR DESCRIPTION
Currently if the event loop is closed ApplicationRunner.run() won't start and the message we get is: Event loop is closed.