### PR TITLE
fix some python3'isms

### DIFF
--- a/autobahn/wamp/cryptosign.py
+++ b/autobahn/wamp/cryptosign.py
@@ -137,10 +137,14 @@ class _SSHPacketReader:
         return value
 
     def get_uint32(self):
-        return int.from_bytes(self.get_bytes(4), 'big')
+        return struct.unpack('>I', self.get_bytes(4))[0]
 
     def get_string(self):
         return self.get_bytes(self.get_uint32())
+
+
+def _makepad(size):
+    return ''.join(chr(x) for x in range(1, size + 1))
 
 
 def _read_ssh_ed25519_privkey(keydata):
@@ -232,7 +236,7 @@ def _read_ssh_ed25519_privkey(keydata):
     comment = packet.get_string()                             # comment
     pad = packet.get_remaining_payload()
 
-    if len(pad) >= block_size or pad != bytes(range(1, len(pad) + 1)):
+    if len(pad) >= block_size or pad != _makepad(len(pad)):
         raise Exception('invalid OpenSSH private key')
 
     # secret key (64 octets) = 32 octets seed || 32 octets secret key derived of seed

--- a/autobahn/wamp/test/test_cryptosign.py
+++ b/autobahn/wamp/test/test_cryptosign.py
@@ -1,0 +1,59 @@
+###############################################################################
+#
+# The MIT License (MIT)
+#
+# Copyright John-Mark Gurney
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+###############################################################################
+
+from __future__ import absolute_import
+
+from autobahn.wamp.cryptosign import _makepad, HAS_CRYPTOSIGN
+
+import autobahn.wamp.cryptosign
+import tempfile
+
+import unittest2 as unittest
+
+keybody = '''-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+QyNTUxOQAAACAa38i/4dNWFuZN/72QAJbyOwZvkUyML/u2b2B1uW4RbQAAAJj4FLyB+BS8
+gQAAAAtzc2gtZWQyNTUxOQAAACAa38i/4dNWFuZN/72QAJbyOwZvkUyML/u2b2B1uW4RbQ
+AAAEBNV9l6aPVVaWYgpthJwM5YJWhRjXKet1PcfHMt4oBFEBrfyL/h01YW5k3/vZAAlvI7
+Bm+RTIwv+7ZvYHW5bhFtAAAAFXNvbWV1c2VyQGZ1bmt0aGF0LmNvbQ==
+-----END OPENSSH PRIVATE KEY-----
+'''
+
+
+class TestKey(unittest.TestCase):
+    def test_pad(self):
+        self.assertEqual(_makepad(0), '')
+        self.assertEqual(_makepad(2), '\x01\x02')
+        self.assertEqual(_makepad(3), '\x01\x02\x03')
+
+    @unittest.skipIf(not HAS_CRYPTOSIGN, 'nacl library not present')
+    def test_key(self):
+        with tempfile.NamedTemporaryFile('w+t') as fp:
+            fp.write(keybody)
+            fp.seek(0)
+
+            key = autobahn.wamp.cryptosign.SigningKey.from_ssh_key(fp.name)
+            self.assertEqual(key.public_key(), '1adfc8bfe1d35616e64dffbd900096f23b066f914c8c2ffbb66f6075b96e116d')


### PR DESCRIPTION
In attempting to get CryptoSign working, I ran into a few python3'isms that make the cryptosign file not compatible w/ python2.

I have not run this through tests on python3 as I'm not at all familiar w/ 3.  From what I read, there may need to be a .encode('latin-1') or something similar on the _makepad call.