### PR TITLE
[WIP] component.start method refactor: handle retries and fire connectfailure events

### DIFF
--- a/autobahn/asyncio/component.py
+++ b/autobahn/asyncio/component.py
@@ -301,7 +301,7 @@ class Component(component.Component):
 
         if loop is None:
             self.log.warn("Using default loop")
-            loop = asyncio.get_default_loop()
+            loop = asyncio.get_event_loop()
 
         return self._start(loop=loop)
 

--- a/autobahn/asyncio/component.py
+++ b/autobahn/asyncio/component.py
@@ -286,7 +286,7 @@ class Component(component.Component):
             assert(False), 'should not arrive here'
 
     # async function
-    def start(self, loop=None, log_level=None):
+    def start(self, loop=None):
         """
         This starts the Component, which means it will start connecting
         (and re-connecting) to its configured transports. A Component
@@ -303,10 +303,10 @@ class Component(component.Component):
             self.log.warn("Using default loop")
             loop = asyncio.get_default_loop()
 
-        return self._start(loop=loop, log_level=log_level)
+        return self._start(loop=loop)
 
 
-def run(components, log_level='info'):
+def run(components):
     """
     High-level API to run a series of components.
 
@@ -322,16 +322,8 @@ def run(components, log_level='info'):
 
     :param components: the Component(s) you wish to run
     :type components: Component or list of Components
-
-    :param log_level: a valid log-level (or None to avoid calling start_logging)
-    :type log_level: string
     """
 
-    # actually, should we even let people "not start" the logging? I'm
-    # not sure that's wise... (double-check: if they already called
-    # txaio.start_logging() what happens if we call it again?)
-    if log_level is not None:
-        txaio.start_logging(level=log_level)
     loop = asyncio.get_event_loop()
     log = txaio.make_logger()
 

--- a/autobahn/asyncio/component.py
+++ b/autobahn/asyncio/component.py
@@ -286,6 +286,26 @@ class Component(component.Component):
         else:
             assert(False), 'should not arrive here'
 
+    # async function
+    def start(self, loop=None, log_level=None):
+        """
+        This starts the Component, which means it will start connecting
+        (and re-connecting) to its configured transports. A Component
+        runs until it is "done", which means one of:
+        - There was a "main" function defined, and it completed successfully;
+        - Something called ``.leave()`` on our session, and we left successfully;
+        - ``.stop()`` was called, and completed successfully;
+        - none of our transports were able to connect successfully (failure);
+        :returns: a Future which will resolve (to ``None``) when we are
+            "done" or with an error if something went wrong.
+        """
+
+        if loop is None:
+            self.log.warn("Using default loop")
+            loop = asyncio.get_default_loop()
+
+        return self._start(loop=loop, log_level=log_level)
+
 
 def run(components, log_level='info'):
     """

--- a/autobahn/asyncio/component.py
+++ b/autobahn/asyncio/component.py
@@ -54,14 +54,6 @@ from autobahn.wamp.exception import ApplicationError
 
 __all__ = ('Component',)
 
-
-def _is_ssl_error(e):
-    """
-    Internal helper.
-    """
-    return isinstance(e, ssl.SSLError)
-
-
 def _unique_list(seq):
     """
     Return a list with unique elements from sequence, preserving order.
@@ -187,6 +179,12 @@ class Component(component.Component):
     The factory of the session we will instantiate.
     """
 
+    def _is_ssl_error(self, e):
+        """
+        Internal helper.
+        """
+        return isinstance(e, ssl.SSLError)
+
     def _check_native_endpoint(self, endpoint):
         if isinstance(endpoint, dict):
             if u'tls' in endpoint:
@@ -287,157 +285,6 @@ class Component(component.Component):
 
         else:
             assert(False), 'should not arrive here'
-
-    # async function
-    def start(self, loop=None, log_level=None):
-        """
-        This starts the Component, which means it will start connecting
-        (and re-connecting) to its configured transports. A Component
-        runs until it is "done", which means one of:
-
-        - There was a "main" function defined, and it completed successfully;
-        - Something called ``.leave()`` on our session, and we left successfully;
-        - ``.stop()`` was called, and completed successfully;
-        - none of our transports were able to connect successfully (failure);
-
-        :returns: a Future which will resolve (to ``None``) when we are
-            "done" or with an error if something went wrong.
-        """
-
-        if log_level is not None:
-            txaio.start_logging(level=log_level)
-
-        if loop is None:
-            self.log.warn("Using default loop")
-            loop = asyncio.get_event_loop()
-
-        # this future will be returned, and thus has the semantics
-        # specified in the docstring.
-        done_f = txaio.create_future()
-
-        connectable_transports = dict()
-
-        # Create a generator of transports that .can_reconnect()
-        def set_connectable_transports():
-            valid_transports = [tp for tp in self._transports if tp.can_reconnect()]
-            connectable_transports['count'] =  len(valid_transports)
-            connectable_transports['gen'] = itertools.cycle(valid_transports)
-
-        set_connectable_transports()
-
-        # issue our first event, then start the reconnect loop
-        f0 = self.fire('start', loop, self)
-
-        def one_reconnect_loop(_):
-            self.log.debug('Entering re-connect loop')
-
-            if not connectable_transports['count']:
-                err_msg = u"Component failed: Exhausted all transport connect attempts"
-                self.log.info(err_msg)
-                try:
-                    raise RuntimeError(err_msg)
-                except RuntimeError as e:
-                    txaio.reject(done_f, e)
-                    return
-
-            def actual_connect(_):
-
-                def handle_connect_error(fail):
-                    unrecoverable_error = False
-
-                    if isinstance(fail.value, asyncio.CancelledError):
-                        unrecoverable_error = True
-
-                    self.log.debug(u'component failed: {error}', error=txaio.failure_message(fail))
-                    self.log.debug(u'{tb}', tb=txaio.failure_format_traceback(fail))
-                    # If this is a "fatal error" that will never work,
-                    # we bail out now
-                    if isinstance(fail.value, ApplicationError):
-                        if fail.value.error in [u'wamp.error.no_such_realm']:
-                            unrecoverable_error = True
-                            self.log.error(u"Fatal error, not reconnecting")
-
-                        self.log.error(u"{msg}", msg=fail.value.error_message())
-
-                    elif isinstance(fail.value, OSError):
-                        # failed to connect entirely, like nobody
-                        # listening etc.
-                        self.log.info(u"Connection failed: {msg}", msg=txaio.failure_message(fail))
-
-                    elif _is_ssl_error(fail.value):
-                        # Quoting pyOpenSSL docs: "Whenever
-                        # [SSL.Error] is raised directly, it has a
-                        # list of error messages from the OpenSSL
-                        # error queue, where each item is a tuple
-                        # (lib, function, reason). Here lib, function
-                        # and reason are all strings, describing where
-                        # and what the problem is. See err(3) for more
-                        # information."
-                        self.log.error(u"TLS failure: {reason}", reason=fail.value.args[1])
-                        self.log.error(u"Marking this transport as failed")
-                        transport.failed()
-                    else:
-                        self.log.error(
-                            u'Connection failed: {error}',
-                            error=txaio.failure_message(fail),
-                        )
-                        # some types of errors should probably have
-                        # stacktraces logged immediately at error
-                        # level, e.g. SyntaxError?
-                        self.log.debug(u'{tb}', tb=txaio.failure_format_traceback(fail))
-
-                    if unrecoverable_error:
-                        txaio.reject(done_f, fail)
-                        return
-
-                    if not transport.can_reconnect():
-                        set_connectable_transports()
-
-                    txaio.call_later(0, one_reconnect_loop, None)
-                    return
-
-                def notify_connect_error(fail):
-                    chain_f = txaio.create_future()
-                    handler_f = self.fire('connectfailure', self, fail.value)
-                    txaio.add_callbacks(
-                        handler_f,
-                        lambda _: txaio.reject(chain_f, fail),
-                        lambda _: txaio.reject(chain_f, fail)
-                    )
-                    return chain_f
-
-                def connect_error(fail):
-                    notify_f = notify_connect_error(fail)
-                    txaio.add_callbacks(notify_f, None, handle_connect_error)
-
-                def session_done(x):
-                    txaio.resolve(done_f, None)
-
-                connect_f = self._connect_once(loop, transport)
-                txaio.add_callbacks(connect_f, session_done, connect_error)
-
-            transport = next(connectable_transports['gen'])
-
-            delay = transport.next_delay()
-            self.log.debug(
-                'trying transport {transport_idx} using connect delay {transport_delay}',
-                transport_idx=transport.idx,
-                transport_delay=delay,
-            )
-
-            delay_f = asyncio.ensure_future(txaio.sleep(delay))
-            txaio.add_callbacks(delay_f, actual_connect, error)
-
-        def error(fail):
-            self.log.info("Internal error {msg}", msg=txaio.failure_message(fail))
-            self.log.debug("{tb}", tb=txaio.failure_format_traceback(fail))
-            txaio.reject(done_f, fail)
-
-        txaio.add_callbacks(f0, one_reconnect_loop, error)
-        return done_f
-
-    def stop(self):
-        return self._session.leave()
 
 
 def run(components, log_level='info'):

--- a/autobahn/asyncio/component.py
+++ b/autobahn/asyncio/component.py
@@ -30,7 +30,6 @@ from __future__ import absolute_import, print_function
 import six
 import ssl  # XXX what Python version is this always available at?
 import signal
-import itertools
 from functools import partial
 
 try:
@@ -49,10 +48,10 @@ from autobahn.asyncio.rawsocket import WampRawSocketClientFactory
 from autobahn.wamp import component
 
 from autobahn.asyncio.wamp import Session
-from autobahn.wamp.exception import ApplicationError
 
 
 __all__ = ('Component',)
+
 
 def _unique_list(seq):
     """

--- a/autobahn/asyncio/component.py
+++ b/autobahn/asyncio/component.py
@@ -306,7 +306,7 @@ class Component(component.Component):
         return self._start(loop=loop)
 
 
-def run(components):
+def run(components, log_level='info'):
     """
     High-level API to run a series of components.
 
@@ -322,8 +322,16 @@ def run(components):
 
     :param components: the Component(s) you wish to run
     :type components: Component or list of Components
+
+    :param log_level: a valid log-level (or None to avoid calling start_logging)
+    :type log_level: string
     """
 
+    # actually, should we even let people "not start" the logging? I'm
+    # not sure that's wise... (double-check: if they already called
+    # txaio.start_logging() what happens if we call it again?)
+    if log_level is not None:
+        txaio.start_logging(level=log_level)
     loop = asyncio.get_event_loop()
     log = txaio.make_logger()
 

--- a/autobahn/twisted/component.py
+++ b/autobahn/twisted/component.py
@@ -324,6 +324,24 @@ class Component(component.Component):
         transport_endpoint = _create_transport_endpoint(reactor, transport.endpoint)
         return transport_endpoint.connect(transport_factory)
 
+    def start(self, reactor=None, log_level=None):
+        """
+        This starts the Component, which means it will start connecting
+        (and re-connecting) to its configured transports. A Component
+        runs until it is "done", which means one of:
+        - There was a "main" function defined, and it completed successfully;
+        - Something called ``.leave()`` on our session, and we left successfully;
+        - ``.stop()`` was called, and completed successfully;
+        - none of our transports were able to connect successfully (failure);
+        :returns: a Deferred that fires (with ``None``) when we are
+            "done" or with a Failure if something went wrong.
+        """
+        if reactor is None:
+            self.log.warn("Using default reactor")
+            from twisted.internet import reactor
+
+        return self._start(loop=reactor, log_level=log_level)
+
 
 def run(components, log_level='info'):
     """

--- a/autobahn/twisted/component.py
+++ b/autobahn/twisted/component.py
@@ -319,7 +319,7 @@ class Component(component.Component):
         transport_endpoint = _create_transport_endpoint(reactor, transport.endpoint)
         return transport_endpoint.connect(transport_factory)
 
-    def start(self, reactor=None, log_level=None):
+    def start(self, reactor=None):
         """
         This starts the Component, which means it will start connecting
         (and re-connecting) to its configured transports. A Component
@@ -335,10 +335,10 @@ class Component(component.Component):
             self.log.warn("Using default reactor")
             from twisted.internet import reactor
 
-        return self._start(loop=reactor, log_level=log_level)
+        return self._start(loop=reactor)
 
 
-def run(components, log_level='info'):
+def run(components):
     """
     High-level API to run a series of components.
 
@@ -352,21 +352,12 @@ def run(components, log_level='info'):
 
     :param components: the Component(s) you wish to run
     :type components: Component or list of Components
-
-    :param log_level: a valid log-level (or None to avoid calling start_logging)
-    :type log_level: string
     """
     # only for Twisted > 12
     # ...so this isn't in all Twisted versions we test against -- need
     # to do "something else" if we can't import .. :/ (or drop some
     # support)
     from twisted.internet.task import react
-
-    # actually, should we even let people "not start" the logging? I'm
-    # not sure that's wise... (double-check: if they already called
-    # txaio.start_logging() what happens if we call it again?)
-    if log_level is not None:
-        txaio.start_logging(level=log_level)
 
     log = txaio.make_logger()
 

--- a/autobahn/twisted/component.py
+++ b/autobahn/twisted/component.py
@@ -338,7 +338,7 @@ class Component(component.Component):
         return self._start(loop=reactor)
 
 
-def run(components):
+def run(components, log_level='info'):
     """
     High-level API to run a series of components.
 
@@ -352,12 +352,21 @@ def run(components):
 
     :param components: the Component(s) you wish to run
     :type components: Component or list of Components
+
+    :param log_level: a valid log-level (or None to avoid calling start_logging)
+    :type log_level: string
     """
     # only for Twisted > 12
     # ...so this isn't in all Twisted versions we test against -- need
     # to do "something else" if we can't import .. :/ (or drop some
     # support)
     from twisted.internet.task import react
+
+    # actually, should we even let people "not start" the logging? I'm
+    # not sure that's wise... (double-check: if they already called
+    # txaio.start_logging() what happens if we call it again?)
+    if log_level is not None:
+        txaio.start_logging(level=log_level)
 
     log = txaio.make_logger()
 

--- a/autobahn/twisted/component.py
+++ b/autobahn/twisted/component.py
@@ -27,9 +27,6 @@
 
 from __future__ import absolute_import, print_function
 
-import itertools
-
-from twisted.internet.defer import inlineCallbacks  # XXX FIXME?
 from twisted.internet.interfaces import IStreamClientEndpoint
 from twisted.internet.endpoints import UNIXClientEndpoint
 from twisted.internet.endpoints import TCP4ClientEndpoint
@@ -55,9 +52,7 @@ from autobahn.twisted.rawsocket import WampRawSocketClientFactory
 
 from autobahn.wamp import component
 
-from autobahn.twisted.util import sleep
 from autobahn.twisted.wamp import Session
-from autobahn.wamp.exception import ApplicationError
 
 
 __all__ = ('Component',)

--- a/autobahn/twisted/test/test_component.py
+++ b/autobahn/twisted/test/test_component.py
@@ -46,7 +46,7 @@ if os.environ.get('USE_TWISTED', False):
         def setUp(self):
             pass
 
-        @patch('autobahn.twisted.component.sleep', return_value=succeed(None))
+        @patch('txaio.sleep', return_value=succeed(None))
         @inlineCallbacks
         def test_successful_connect(self, fake_sleep):
             endpoint = Mock()

--- a/autobahn/twisted/test/test_component.py
+++ b/autobahn/twisted/test/test_component.py
@@ -118,7 +118,7 @@ if os.environ.get('USE_TWISTED', False):
                 # make sure we fire all our time-outs
                 reactor.advance(3600)
 
-        @patch('autobahn.twisted.component.sleep', return_value=succeed(None))
+        @patch('txaio.sleep', return_value=succeed(None))
         @inlineCallbacks
         def test_connect_no_auth_method(self, fake_sleep):
             endpoint = Mock()

--- a/autobahn/wamp/component.py
+++ b/autobahn/wamp/component.py
@@ -482,12 +482,6 @@ class Component(ObservableMixin):
         if log_level is not None:
             txaio.set_global_log_level(log_level)
 
-        # run() will always pass in a loop, ensure direct callers of this
-        # method do the same
-        if loop is None:
-            self.log.info("No event loop specified")
-            raise RuntimeError("An even loop must be passed to start()")
-
         # this future will be returned, and thus has the semantics
         # specified in the docstring.
         done_f = txaio.create_future()

--- a/autobahn/wamp/component.py
+++ b/autobahn/wamp/component.py
@@ -461,7 +461,7 @@ class Component(ObservableMixin):
                 return True
         return False
 
-    def start(self, loop=None, log_level=None):
+    def _start(self, loop=None, log_level=None):
         """
         This starts the Component, which means it will start connecting
         (and re-connecting) to its configured transports. A Component

--- a/autobahn/wamp/component.py
+++ b/autobahn/wamp/component.py
@@ -27,6 +27,7 @@
 
 from __future__ import absolute_import
 
+import itertools
 import six
 import random
 from functools import wraps, partial
@@ -403,13 +404,13 @@ class Component(ObservableMixin):
         """
         self.set_valid_events(
             [
-                'start',        # fired by subclass
+                'start',        # fired by base class
                 'connect',      # fired by ApplicationSession
                 'join',         # fired by ApplicationSession
                 'ready',        # fired by ApplicationSession
                 'leave',        # fired by ApplicationSession
                 'disconnect',   # fired by ApplicationSession
-                'connectfailure',  # fired by subclass
+                'connectfailure',   # fired by base class
             ]
         )
 
@@ -460,11 +461,160 @@ class Component(ObservableMixin):
                 return True
         return False
 
-    def start(self, reactor_or_loop):
-        raise RuntimeError('not implemented')
+    def start(self, loop=None, log_level=None):
+        """
+        This starts the Component, which means it will start connecting
+        (and re-connecting) to its configured transports. A Component
+        runs until it is "done", which means one of:
+
+        - There was a "main" function defined, and it completed successfully;
+        - Something called ``.leave()`` on our session, and we left successfully;
+        - ``.stop()`` was called, and completed successfully;
+        - none of our transports were able to connect successfully (failure);
+
+        :returns: a Future/Deferred which will resolve (to ``None``) when we are
+            "done" or with an error if something went wrong.
+        """
+
+        # Component users self-managing loop & logging need to be able to set
+        # log_level otherwise only info level library log msgs are logged
+        # http://txaio.readthedocs.io/en/latest/programming-guide.html#starting-logging-yourself
+        if log_level is not None:
+            txaio.set_global_log_level(log_level)
+
+        # run() will always pass in a loop, ensure direct callers of this
+        # method do the same
+        if loop is None:
+            self.log.info("No event loop specified")
+            raise RuntimeError("An even loop must be passed to start()")
+
+        # this future will be returned, and thus has the semantics
+        # specified in the docstring.
+        done_f = txaio.create_future()
+
+        # Create a generator of transports that .can_reconnect()
+        transport_gen = itertools.cycle(self._transports)
+
+        # this is a 1-element list so we can set it from closures in
+        # this function
+        transport_candidate = [0]
+
+        def error(fail):
+            self.log.info("Internal error {msg}", msg=txaio.failure_message(fail))
+            self.log.debug("{tb}", tb=txaio.failure_format_traceback(fail))
+            txaio.reject(done_f, fail)
+
+        def attempt_connect(_):
+
+            def handle_connect_error(fail):
+                unrecoverable_error = False
+
+                # FIXME - make txaio friendly
+                # Can connect_f ever be in a cancelled state?
+                # if txaio.using_asyncio and isinstance(fail.value, asyncio.CancelledError):
+                #     unrecoverable_error = True
+
+                self.log.debug(u'component failed: {error}', error=txaio.failure_message(fail))
+                self.log.debug(u'{tb}', tb=txaio.failure_format_traceback(fail))
+                # If this is a "fatal error" that will never work,
+                # we bail out now
+                if isinstance(fail.value, ApplicationError):
+                    if fail.value.error in [u'wamp.error.no_such_realm']:
+                        unrecoverable_error = True
+                        self.log.error(u"Fatal error, not reconnecting")
+
+                    self.log.error(u"{msg}", msg=fail.value.error_message())
+
+                elif isinstance(fail.value, OSError):
+                    # failed to connect entirely, like nobody
+                    # listening etc.
+                    self.log.info(u"Connection failed: {msg}", msg=txaio.failure_message(fail))
+
+                elif self._is_ssl_error(fail.value): #     # Quoting pyOpenSSL docs: "Whenever
+                    # [SSL.Error] is raised directly, it has a
+                    # list of error messages from the OpenSSL
+                    # error queue, where each item is a tuple
+                    # (lib, function, reason). Here lib, function
+                    # and reason are all strings, describing where
+                    # and what the problem is. See err(3) for more
+                    # information."
+                    self.log.error(u"TLS failure: {reason}", reason=fail.value.args[1])
+                    self.log.error(u"Marking this transport as failed")
+                    transport.failed()
+                else:
+                    self.log.error(
+                        u'Connection failed: {error}',
+                        error=txaio.failure_message(fail),
+                    )
+                    # some types of errors should probably have
+                    # stacktraces logged immediately at error
+                    # level, e.g. SyntaxError?
+                    self.log.debug(u'{tb}', tb=txaio.failure_format_traceback(fail))
+
+                if unrecoverable_error:
+                    txaio.reject(done_f, fail)
+                    return
+
+                txaio.call_later(0, transport_check, None)
+                return
+
+            def notify_connect_error(fail):
+                chain_f = txaio.create_future()
+                handler_f = self.fire('connectfailure', self, fail.value)
+                txaio.add_callbacks(
+                    handler_f,
+                    lambda _: txaio.reject(chain_f, fail),
+                    lambda _: txaio.reject(chain_f, fail)
+                )
+                return chain_f
+
+            def connect_error(fail):
+                notify_f = notify_connect_error(fail)
+                txaio.add_callbacks(notify_f, None, handle_connect_error)
+
+            def session_done(x):
+                txaio.resolve(done_f, None)
+
+            connect_f = self._connect_once(loop, transport_candidate[0])
+            txaio.add_callbacks(connect_f, session_done, connect_error)
+
+        def transport_check(_):
+            self.log.debug('Entering re-connect loop')
+
+            if not self._can_reconnect():
+                err_msg = u"Component failed: Exhausted all transport connect attempts"
+                self.log.info(err_msg)
+                try:
+                    raise RuntimeError(err_msg)
+                except RuntimeError as e:
+                    txaio.reject(done_f, e)
+                    return
+
+            while True:
+
+                transport = next(transport_gen)
+
+                if transport.can_reconnect():
+                    transport_candidate[0] = transport
+                    break
+
+            delay = transport.next_delay()
+            self.log.debug(
+                'trying transport {transport_idx} using connect delay {transport_delay}',
+                transport_idx=transport.idx,
+                transport_delay=delay,
+            )
+
+            delay_f = txaio.sleep(delay)
+            txaio.add_callbacks(delay_f, attempt_connect, error)
+
+        # issue our first event, then start the reconnect loop
+        start_f = self.fire('start', loop, self)
+        txaio.add_callbacks(start_f, transport_check, error)
+        return done_f
 
     def stop(self):
-        raise RuntimeError('not implemented')
+        return self._session.leave()
 
     def _connect_once(self, reactor, transport):
 
@@ -569,6 +719,7 @@ class Component(ObservableMixin):
                 return session
 
         transport.connect_attempts += 1
+
         d = self._connect_transport(reactor, transport, create_session)
 
         def on_connect_sucess(proto):

--- a/autobahn/wamp/component.py
+++ b/autobahn/wamp/component.py
@@ -276,7 +276,7 @@ class _Transport(object):
     def can_reconnect(self):
         if self._permanent_failure:
             return False
-        if self.max_retries == u'unlimited':
+        if self.max_retries == -1:
             return True
         return self.connect_attempts < self.max_retries + 1
 
@@ -284,7 +284,7 @@ class _Transport(object):
         if self.connect_attempts == 0:
             # if we never tried before, try immediately
             return 0
-        elif self.max_retries != 'unlimited' and self.connect_attempts >= self.max_retries + 1:
+        elif self.max_retries != -1 and self.connect_attempts >= self.max_retries + 1:
             raise RuntimeError('max reconnects reached')
         else:
             self.retry_delay = self.retry_delay * self.retry_delay_growth

--- a/autobahn/wamp/component.py
+++ b/autobahn/wamp/component.py
@@ -507,7 +507,9 @@ class Component(ObservableMixin):
                 # If this is a "fatal error" that will never work,
                 # we bail out now
                 if isinstance(fail.value, ApplicationError):
-                    if fail.value.error in [u'wamp.error.no_such_realm']:
+                    if fail.value.error in [
+                            u'wamp.error.no_such_realm',
+                            u'wamp.error.no_auth_method']:
                         unrecoverable_error = True
                         self.log.error(u"Fatal error, not reconnecting")
 
@@ -531,14 +533,14 @@ class Component(ObservableMixin):
                     self.log.error(u"Marking this transport as failed")
                     transport_candidate[0].failed()
                 else:
+                    # This is some unknown failure, e.g. could
+                    # be SyntaxError etc so we're aborting the
+                    # whole mission
                     self.log.error(
                         u'Connection failed: {error}',
                         error=txaio.failure_message(fail),
                     )
-                    # some types of errors should probably have
-                    # stacktraces logged immediately at error
-                    # level, e.g. SyntaxError?
-                    self.log.debug(u'{tb}', tb=txaio.failure_format_traceback(fail))
+                    unrecoverable_error = True
 
                 if unrecoverable_error:
                     txaio.reject(done_f, fail)

--- a/autobahn/wamp/component.py
+++ b/autobahn/wamp/component.py
@@ -276,13 +276,15 @@ class _Transport(object):
     def can_reconnect(self):
         if self._permanent_failure:
             return False
-        return self.connect_attempts < self.max_retries
+        if self.max_retries == u'unlimited':
+            return True
+        return self.connect_attempts < self.max_retries + 1
 
     def next_delay(self):
         if self.connect_attempts == 0:
             # if we never tried before, try immediately
             return 0
-        elif self.connect_attempts >= self.max_retries:
+        elif self.max_retries != 'unlimited' and self.connect_attempts >= self.max_retries + 1:
             raise RuntimeError('max reconnects reached')
         else:
             self.retry_delay = self.retry_delay * self.retry_delay_growth
@@ -401,12 +403,13 @@ class Component(ObservableMixin):
         """
         self.set_valid_events(
             [
-                'start',        # fired by base class
+                'start',        # fired by subclass
                 'connect',      # fired by ApplicationSession
                 'join',         # fired by ApplicationSession
                 'ready',        # fired by ApplicationSession
                 'leave',        # fired by ApplicationSession
                 'disconnect',   # fired by ApplicationSession
+                'connectfailure',  # fired by subclass
             ]
         )
 

--- a/autobahn/wamp/component.py
+++ b/autobahn/wamp/component.py
@@ -530,7 +530,8 @@ class Component(ObservableMixin):
                     # listening etc.
                     self.log.info(u"Connection failed: {msg}", msg=txaio.failure_message(fail))
 
-                elif self._is_ssl_error(fail.value): #     # Quoting pyOpenSSL docs: "Whenever
+                elif self._is_ssl_error(fail.value):
+                    # Quoting pyOpenSSL docs: "Whenever
                     # [SSL.Error] is raised directly, it has a
                     # list of error messages from the OpenSSL
                     # error queue, where each item is a tuple
@@ -540,7 +541,7 @@ class Component(ObservableMixin):
                     # information."
                     self.log.error(u"TLS failure: {reason}", reason=fail.value.args[1])
                     self.log.error(u"Marking this transport as failed")
-                    transport.failed()
+                    transport_candidate[0].failed()
                 else:
                     self.log.error(
                         u'Connection failed: {error}',

--- a/autobahn/wamp/component.py
+++ b/autobahn/wamp/component.py
@@ -461,7 +461,7 @@ class Component(ObservableMixin):
                 return True
         return False
 
-    def _start(self, loop=None, log_level=None):
+    def _start(self, loop=None):
         """
         This starts the Component, which means it will start connecting
         (and re-connecting) to its configured transports. A Component
@@ -475,12 +475,6 @@ class Component(ObservableMixin):
         :returns: a Future/Deferred which will resolve (to ``None``) when we are
             "done" or with an error if something went wrong.
         """
-
-        # Component users self-managing loop & logging need to be able to set
-        # log_level otherwise only info level library log msgs are logged
-        # http://txaio.readthedocs.io/en/latest/programming-guide.html#starting-logging-yourself
-        if log_level is not None:
-            txaio.set_global_log_level(log_level)
 
         # this future will be returned, and thus has the semantics
         # specified in the docstring.


### PR DESCRIPTION
Requesting comments on this approach before going further.

Only asyncio component done for now.

1. Component transport dict option will now work:
    max_retries: int # -1 for unlimited, 0 for a one time connect attempt
   Connect attempts will respect multiple transport dicts max_retries option.

2. Added 'connectfailure' component lifecycle event to return the connect exception as currently there's no way for a component user to be notified of connection errors.

3. Tweaked the max_retries handling code as it was actually working as a max_tries option

4. Added logging option to component.start() as logging was only working if using run([component]) but not when calling component.start if managing the event loop yourself.

First time tinkering with asyncio and txaio so a couple of things I wasn't sure of:
 
5. How to handle the gathered future returned from self.fire('connectfailure', fail)  if component user's component.on('connectfailure', func) handler raises an exception?  Right now any raised exception in the handler is swallowed and library goes on to handle the original failure exception - acceptable?

6. When there are no more transport connect attempts left I want to reject the done_f future with a meaningful exception, not just return the exception from the last failed connect attempt, so used the try/except approach to reject component future with a RuntimeError - is there a better exception to use?  TransportLost looks like a WAMP level exception for when an established session loses its transport.