### PR TITLE
Fix proxy support

### DIFF
--- a/autobahn/websocket/protocol.py
+++ b/autobahn/websocket/protocol.py
@@ -3362,13 +3362,13 @@ class WebSocketClientProtocol(WebSocketProtocol):
         """
         # construct proxy connect HTTP request
         #
-        request = b"CONNECT %s:%d HTTP/1.1\x0d\x0a" % (self.factory.host.encode("utf-8"), self.factory.port)
-        request += b"Host: %s:%d\x0d\x0a" % (self.factory.host.encode("utf-8"), self.factory.port)
-        request += b"\x0d\x0a"
+        request = "CONNECT %s:%d HTTP/1.1\x0d\x0a" % (self.factory.host, self.factory.port)
+        request += "Host: %s:%d\x0d\x0a" % (self.factory.host, self.factory.port)
+        request += "\x0d\x0a"
 
         self.log.debug("{request}", request=request)
 
-        self.sendData(request)
+        self.sendData(request.encode('utf8'))
 
     def processProxyConnect(self):
         """


### PR DESCRIPTION
This addressed two issues:

1) With each line being considered a byte, it was incompatible and breaking
percent formatting.

2) The dual encoding would actually cause 503 HTTP errors in the proxy itself.
Things like squid would attempt to connect to b'http://url.com' and thus not
work.