### PR TITLE
Ensure that a future is not done before rejecting it

### DIFF
--- a/autobahn/wamp/protocol.py
+++ b/autobahn/wamp/protocol.py
@@ -1163,7 +1163,9 @@ class ApplicationSession(BaseSession):
                 request_id=request.request_id,
                 request_type=request.__class__.__name__,
             )
-            txaio.reject(request.on_reply, exc)
+            if not txaio.is_called(request.on_reply):
+                txaio.reject(request.on_reply, exc)
+
             # wait for any async-ness in the error handlers for on_reply
             txaio.add_callbacks(d, lambda _: request.on_reply, lambda _: request.on_reply)
         return d

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ Changelog
 master (unreleased)
 -------------------
 
+* fix: don't try to reject cancelled futures within pending requests when closing the session
 
 
 17.9.3


### PR DESCRIPTION
This can happen if a task is waiting on a future but the task gets
cancelled. As a consequence, the future is cancelled as well.
Therefore Autobahn must first check that the future is not complete
before attempting to reject it.