### PR TITLE
passthrough unregisterProducer to complement registerProducer

### DIFF
--- a/autobahn/asyncio/websocket.py
+++ b/autobahn/asyncio/websocket.py
@@ -190,6 +190,9 @@ class WebSocketAdapterProtocol(asyncio.Protocol):
     def registerProducer(self, producer, streaming):
         raise Exception("not implemented")
 
+    def unregisterProducer(self):
+        raise Exception("not implemented")
+
 
 @public
 class WebSocketServerProtocol(WebSocketAdapterProtocol, protocol.WebSocketServerProtocol):

--- a/autobahn/twisted/websocket.py
+++ b/autobahn/twisted/websocket.py
@@ -181,6 +181,11 @@ class WebSocketAdapterProtocol(twisted.internet.protocol.Protocol):
         """
         self.transport.registerProducer(producer, streaming)
 
+    def unregisterProducer(self):
+        """
+        Unregister Twisted producer with this protocol.
+        """
+        self.transport.unregisterProducer()
 
 @public
 class WebSocketServerProtocol(WebSocketAdapterProtocol, protocol.WebSocketServerProtocol):

--- a/autobahn/twisted/websocket.py
+++ b/autobahn/twisted/websocket.py
@@ -187,6 +187,7 @@ class WebSocketAdapterProtocol(twisted.internet.protocol.Protocol):
         """
         self.transport.unregisterProducer()
 
+
 @public
 class WebSocketServerProtocol(WebSocketAdapterProtocol, protocol.WebSocketServerProtocol):
     """

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ Changelog
 master (unreleased)
 -------------------
 
+* fix: pass `unregisterProducer` through to twisted to complement `WebSocketAdapterProtocol.registerProducer` (#875)
 
 17.10.1
 -------


### PR DESCRIPTION
fixes https://github.com/crossbario/autobahn-python/issues/875

simply wrap `unregisterProducer` in the same style as `registerProducer`.