### PR TITLE
Remove unwarranted semicolon.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -116,7 +116,7 @@ actions that WAMP provides:
             def add2(x, y):
                 return x + y
 
-            self.register(add2, 'com.myapp.add2');
+            self.register(add2, 'com.myapp.add2')
 
             # 4. call a remote procedure
             res = yield self.call('com.myapp.add2', 2, 3)


### PR DESCRIPTION
Remove an unwarranted semicolon from Python example source code in README.rst.