### PR TITLE
Don't install default reactor unnecessarily

### DIFF
--- a/autobahn/twisted/choosereactor.py
+++ b/autobahn/twisted/choosereactor.py
@@ -65,7 +65,8 @@ def install_optimal_reactor(verbose=False):
         if current_reactor != 'KQueueReactor':
             try:
                 from twisted.internet import kqreactor
-                kqreactor.install()
+                if 'twisted.internet.reactor' not in sys.modules:
+                    kqreactor.install()
             except:
                 log.critical("Running on *BSD or MacOSX, but cannot install kqueue Twisted reactor")
                 log.warn("{tb}", tb=traceback.format_exc())


### PR DESCRIPTION
On MacOS (at least) crossbar won't run because it tries to load a default reactor although it is already loaded.
This two-line fix to choosereactor.py simply checks to see if the module has been loaded before attempting to load it.
Possibly this check should be in twister/internet/main.py but that is marked as an obsolete compatibility method anyway so I put the fix here.

This addresses these corssbar issues:
crossbario/crossbar#1200
crossbario/crossbar#939
crossbario/crossbar#920
crossbario/crossbar#929