### PR TITLE
twisted trunk doesn't work on python3.3

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist =
     py27-{tw121,tw132,tw154,tw165,twtrunk,asyncio}
     pypy-{tw121,tw132,tw154,tw165,twtrunk,asyncio}
     pypy3-{tw154,tw165,twtrunk,asyncio}
-    py33-{tw154,tw165,twtrunk,asyncio}
+    py33-{tw154,tw165,asyncio}
     py34-{tw154,tw165,twtrunk,asyncio}
     py35-{tw154,tw165,twtrunk,asyncio}
     py36-{tw154,tw165,twtrunk,asyncio}


### PR DESCRIPTION
See https://github.com/twisted/twisted/pull/943 Twisted dropped support for Python 3.3

This PR just removes it from the Tox matrix so builds pass. Can we add some magic in setup.py that a) means a python3.3 gets Twisted no newer than 17.9.x but b) others get newest Twisted? Or, crossbar drops python3.3 support as well (which then needs doc changes).