### PR TITLE
wamp-scram

### DIFF
--- a/autobahn/asyncio/wamp.py
+++ b/autobahn/asyncio/wamp.py
@@ -287,6 +287,9 @@ class Session(protocol._SessionShim):
     # XXX these methods are redundant, but put here for possibly
     # better clarity; maybe a bad idea.
 
+    def on_welcome(self, welcome_msg):
+        pass
+
     def on_join(self, details):
         pass
 

--- a/autobahn/twisted/component.py
+++ b/autobahn/twisted/component.py
@@ -41,8 +41,8 @@ try:
     from OpenSSL import SSL
 except ImportError as e:
     _TLS = False
-    if 'OpenSSL' not in str(e):
-        raise
+    # there's no optionsForClientTLS in older Twisteds or we might be
+    # missing OpenSSL entirely.
 
 import six
 import txaio

--- a/autobahn/twisted/wamp.py
+++ b/autobahn/twisted/wamp.py
@@ -763,6 +763,9 @@ class Session(protocol._SessionShim):
     # XXX these methods are redundant, but put here for possibly
     # better clarity; maybe a bad idea.
 
+    def on_welcome(self, welcome_msg):
+        pass
+
     def on_join(self, details):
         pass
 

--- a/autobahn/wamp/auth.py
+++ b/autobahn/wamp/auth.py
@@ -263,14 +263,14 @@ class AuthScram(object):
         # '$argon2i$v=19$m=512,t=2,p=2$5VtWOO3cGWYQHEMaYGbsfQ$AcmqasQgW/wI6wAHAMk4aQ'
 
         _, tag, ver, options, salt_data, hash_data = rawhash.split(b'$')
-        salted_password = hash_data  # KDF(Normalize(password), salt, params...)
+        salted_password = hash_data
         client_key = hmac.new(salted_password, b"Client Key", hashlib.sha256).digest()
         stored_key = hashlib.new('sha256', client_key).digest()
 
         client_signature = hmac.new(stored_key, auth_message.encode('ascii'), hashlib.sha256).digest()
-        client_proof = base64.b64encode(xor_array(client_key, client_signature))
+        client_proof = xor_array(client_key, client_signature)
 
-        return client_proof
+        return base64.b64encode(client_proof)
 
 
 IAuthenticator.register(AuthScram)

--- a/autobahn/wamp/auth.py
+++ b/autobahn/wamp/auth.py
@@ -271,7 +271,7 @@ class AuthScram(object):
         server_nonce = challenge.extra[u'nonce']  # base64
         salt = challenge.extra[u'salt']  # base64
         iterations = int(challenge.extra[u'iterations'])
-        memory = int(challenge.extra(u'memory', -1))
+        memory = int(challenge.extra.get(u'memory', -1))
         password = self._args['password'].encode('utf8')  # supplied by user
         authid = saslprep(self._args['authid'])
         algorithm = challenge.extra[u'kdf']

--- a/autobahn/wamp/auth.py
+++ b/autobahn/wamp/auth.py
@@ -264,10 +264,10 @@ class AuthScram(object):
 
         _, tag, ver, options, salt_data, hash_data = rawhash.split(b'$')
         salted_password = hash_data  # KDF(Normalize(password), salt, params...)
-        client_key = hmac.new(salted_password, b"Client Key").digest()
+        client_key = hmac.new(salted_password, b"Client Key", hashlib.sha256).digest()
         stored_key = hashlib.new('sha256', client_key).digest()
 
-        client_signature = hmac.new(stored_key, auth_message.encode('ascii')).digest()
+        client_signature = hmac.new(stored_key, auth_message.encode('ascii'), hashlib.sha256).digest()
         client_proof = base64.b64encode(xor_array(client_key, client_signature))
 
         return client_proof

--- a/autobahn/wamp/auth.py
+++ b/autobahn/wamp/auth.py
@@ -109,6 +109,9 @@ class AuthAnonymous(object):
             "on_challenge called on anonymous authentication"
         )
 
+    def on_welcome(self, msg):
+        return None
+
 
 IAuthenticator.register(AuthAnonymous)
 
@@ -132,6 +135,9 @@ class AuthTicket(object):
     def on_challenge(self, session, challenge):
         assert challenge.method == u"ticket"
         return self._ticket
+
+    def on_welcome(self, msg):
+        return None
 
 
 IAuthenticator.register(AuthTicket)
@@ -234,43 +240,56 @@ class AuthScram(object):
         channel_binding = challenge.extra.get(u'channel_binding', u'')
         server_nonce = challenge.extra[u'nonce']  # base64
         salt = challenge.extra[u'salt']  # base64
-        cost = int(challenge.extra[u'cost'])
-        memory = int(challenge.extra.get(u'memory', 512))
-        parallel = int(challenge.extra.get(u'parallel', 2))
+        iterations = int(challenge.extra[u'iterations'])
+        memory = int(challenge.extra.get(u'memory', 512))  # XXX required for argon2id, right?
         password = self._args['password'].encode('utf8')  # supplied by user
         authid = saslprep(self._args['authid'])
+        algorithm = challenge.extra[u'kdf']
         client_nonce = self._client_nonce
 
-        auth_message = (
+        self._auth_message = (
             "{client_first_bare},{server_first},{client_final_no_proof}".format(
                 client_first_bare="n={},r={}".format(authid, client_nonce),
-                server_first="r={},s={},i={}".format(server_nonce, salt, cost),
+                server_first="r={},s={},i={}".format(server_nonce, salt, iterations),
                 client_final_no_proof="c={},r={}".format(channel_binding, server_nonce),
+            ).encode('ascii')
+        )
+
+        if algorithm == u'argon2id-13':
+            self._salted_password = _hash_argon2id13_secret(password, salt, iterations, memory)
+        elif algorithm == u'pbkdf2':
+            self._salted_password = _hash_pbkdf2_secret(password, salt, iterations)
+        else:
+            raise RuntimeError(
+                "WAMP-SCRAM specified unknown KDF '{}'".format(algorithm)
             )
-        )
 
-        rawhash = hash_secret(
-            secret=password,
-            salt=base64.b64decode(salt),
-            time_cost=cost,
-            memory_cost=memory,
-            parallelism=parallel,
-            hash_len=16,  # another knob?
-            type=Type.ID,
-            version=19,
-        )
-        # spits out stuff like:
-        # '$argon2i$v=19$m=512,t=2,p=2$5VtWOO3cGWYQHEMaYGbsfQ$AcmqasQgW/wI6wAHAMk4aQ'
-
-        _, tag, ver, options, salt_data, hash_data = rawhash.split(b'$')
-        salted_password = hash_data
-        client_key = hmac.new(salted_password, b"Client Key", hashlib.sha256).digest()
+        client_key = hmac.new(self._salted_password, b"Client Key", hashlib.sha256).digest()
         stored_key = hashlib.new('sha256', client_key).digest()
 
-        client_signature = hmac.new(stored_key, auth_message.encode('ascii'), hashlib.sha256).digest()
+        client_signature = hmac.new(stored_key, self._auth_message, hashlib.sha256).digest()
         client_proof = xor_array(client_key, client_signature)
 
         return base64.b64encode(client_proof)
+
+    def on_welcome(self, session, authextra):
+        """
+        When the server is satisfied, it sends a 'WELCOME' message.
+
+        This hook allows us an opportunity to deny the session right
+        before it gets set up -- we check the server-signature thus
+        authorizing the server and if it fails we drop the connection.
+        """
+        alleged_server_sig = base64.b64decode(authextra['scram_server_signature'])
+        server_key = hmac.new(self._salted_password, b"Server Key", hashlib.sha256).digest()
+        server_signature = hmac.new(server_key, self._auth_message, hashlib.sha256).digest()
+        if not hmac.compare_digest(server_signature, alleged_server_sig):
+            session.log.error("Verification of server SCRAM signature failed")
+            return "Verification of server SCRAM signature failed"
+        session.log.info(
+            "Verification of server SCRAM signature successful"
+        )
+        return None
 
 
 IAuthenticator.register(AuthScram)

--- a/autobahn/wamp/interfaces.py
+++ b/autobahn/wamp/interfaces.py
@@ -406,6 +406,22 @@ class ISession(object):
 
     @public
     @abc.abstractmethod
+    def onWelcome(self, welcome_msg):
+        """
+        Callback fired after the peer has successfully authenticated. If
+        this returns anything other than None/False, the session is
+        aborted and the return value is used as an error message.
+
+        May return a Deferred/Future.
+
+        :param welcome_msg: The WELCOME message received from the server
+        :type challenge: Instance of :class:`autobahn.wamp.message.Welcome`.
+
+        :return: None, or an error message
+        """
+
+    @public
+    @abc.abstractmethod
     def onJoin(self, details):
         """
         Callback fired when WAMP session has been established.
@@ -675,6 +691,20 @@ class IAuthenticator(object):
     @abc.abstractmethod
     def on_challenge(self, session, challenge):
         """
+        Formulate a challenge response for the given session and Challenge
+        instance. This is sent to the server in the AUTHENTICATE
+        message.
+        """
+
+    @abc.abstractmethod
+    def on_welcome(self, authextra):
+        """
+        This hook is called when the onWelcome/on_welcome hook is invoked
+        in the protocol, with the 'authextra' dict extracted from the
+        Welcome message. Usually this is used to verify the final
+        message from the server (e.g. for mutual authentication).
+
+        :return: None if the session is successful or an error-message
         """
 
 

--- a/autobahn/wamp/message.py
+++ b/autobahn/wamp/message.py
@@ -273,7 +273,7 @@ def check_or_raise_extra(value, message=u"WAMP message invalid"):
     if type(value) != dict:
         raise ProtocolError(u"{0}: invalid type {1}".format(message, type(value)))
     for k in value.keys():
-        if type(k) != six.text_type:
+        if not isinstance(k, six.text_type):
             raise ProtocolError(u"{0}: invalid type {1} for key '{2}'".format(message, type(k), k))
     return value
 

--- a/autobahn/wamp/protocol.py
+++ b/autobahn/wamp/protocol.py
@@ -1615,9 +1615,6 @@ class _SessionShim(ApplicationSession):
     #: name -> IAuthenticator
     _authenticators = None
 
-    def onWelcome(self, msg):
-        return self.on_welcome(msg)
-
     def onJoin(self, details):
         return self.on_join(details)
 
@@ -1656,7 +1653,7 @@ class _SessionShim(ApplicationSession):
         except KeyError:
             raise RuntimeError(
                 "Received onWelcome for unknown authmethod '{}'".format(
-                    authmethod
+                    msg.authmethod
                 )
             )
         return authenticator.on_welcome(self, msg.authextra)

--- a/autobahn/wamp/protocol.py
+++ b/autobahn/wamp/protocol.py
@@ -1594,13 +1594,16 @@ class ApplicationSession(BaseSession):
         return on_reply
 
 
-# this is NOT public; import from either autobahn.asyncio.wamp or
-# autobahn.twisted.wamp
 class _SessionShim(ApplicationSession):
     """
     shim that lets us present pep8 API for user-classes to override,
     but also backwards-compatible for existing code using
     ApplicationSession "directly".
+
+    **NOTE:** this is not public or intended for use; you should import
+    either :class:`autobahn.asyncio.wamp.Session` or
+    :class:`autobahn.twisted.wamp.Session` depending on which async
+    framework you're using.
     """
 
     #: name -> IAuthenticator

--- a/autobahn/wamp/protocol.py
+++ b/autobahn/wamp/protocol.py
@@ -1158,6 +1158,12 @@ class ApplicationSession(BaseSession):
         Implements :func:`autobahn.wamp.interfaces.ISession.onJoin`
         """
 
+    @public
+    def onWelcome(self, msg):
+        """
+        Implements :func:`autobahn.wamp.interfaces.ISession.onWelcome`
+        """
+
     def _errback_outstanding_requests(self, exc):
         """
         Errback any still outstanding requests with exc.

--- a/autobahn/wamp/protocol.py
+++ b/autobahn/wamp/protocol.py
@@ -1648,6 +1648,8 @@ class _SessionShim(ApplicationSession):
         return authenticator.on_challenge(self, challenge)
 
     def onWelcome(self, msg):
+        if msg.authmethod is None:  # no authentication
+            return
         try:
             authenticator = self._authenticators[msg.authmethod]
         except KeyError:

--- a/examples/router/.crossbar/config.json
+++ b/examples/router/.crossbar/config.json
@@ -157,11 +157,11 @@
                                         "carol": {
                                             "role": "authenticated",
                                             "memory": 512,
-                                            "cost": 4096,
-                                            "parallel": 2,
-                                            "salt": "5fca5acd7f7c72ecf4dce05db9e09789",
-                                            "stored-key": "4a33525e3c7cfcfe441756c6c9fc9d2ce49b951aec93461b52697ac740d5fadf",
-                                            "server-key": "1ae324c43ee1985a83a45dda852e5011084a76bb45acf47e8f475cd8ce5de5e0"
+                                            "kdf": "argon2id-13",
+                                            "iterations": 4096,
+                                            "salt": "accaa46d16de59a12db736c8ed2cc90c",
+                                            "stored-key": "6524cf40c287834819a9c46a591f75be42d67f253aec73fe97d55736d1a928bd",
+                                            "server-key": "877b77c9fb3e12c13948812d9db909ceb794de9a7ec8a0c025f57ad8dff24ab8"
                                         }
                                     }
                                 },

--- a/examples/twisted/wamp/component/create_argon2id_password.py
+++ b/examples/twisted/wamp/component/create_argon2id_password.py
@@ -22,7 +22,7 @@ hash_data = hash_secret(
     salt=salt,
     time_cost=4096,
     memory_cost=512,
-    parallelism=2,
+    parallelism=1,
     hash_len=16,
     type=Type.ID,
     version=19,
@@ -30,7 +30,7 @@ hash_data = hash_secret(
 
 _, tag, v, params, othersalt, salted_password = hash_data.decode('ascii').split('$')
 assert tag == 'argon2id'
-assert v == 'v=19'
+assert v == 'v=19'  # argon's version 1.3 is represented as 0x13, which is 19 decimal...
 params = {
     k: v
     for k, v in
@@ -46,8 +46,8 @@ server_key = hmac.new(salted_password, b"Server Key", hashlib.sha256).digest()
 # static-configured scram principal; see the example router config
 key = {
     "memory": int(params['m']),
-    "cost": int(params['t']),
-    "parallel": int(params['p']),
+    "kdf": "argon2id-13",
+    "iterations": int(params['t']),
     "salt": binascii.b2a_hex(salt).decode('ascii'),
     "stored-key": binascii.b2a_hex(stored_key).decode('ascii'),
     "server-key": binascii.b2a_hex(server_key).decode('ascii'),

--- a/examples/twisted/wamp/component/create_argon2id_password.py
+++ b/examples/twisted/wamp/component/create_argon2id_password.py
@@ -7,7 +7,6 @@ import hashlib
 import base64
 import binascii
 from passlib.utils import saslprep
-from pprint import pprint
 from argon2.low_level import hash_secret
 from argon2.low_level import Type
 

--- a/examples/twisted/wamp/component/frontend_scram.py
+++ b/examples/twisted/wamp/component/frontend_scram.py
@@ -14,6 +14,7 @@ component = Component(
             u"authid": u"carol",
             u"authrole": u"authenticated",
             u"password": u"p4ssw0rd",
+            u"kdf": u"argon2id13",
         }
     }
 )

--- a/setup.py
+++ b/setup.py
@@ -112,10 +112,17 @@ extras_require_encryption = [
     'pyqrcode>=1.1'             # BSD license
 ]
 
+# Support for WAMP-SCRAM authentication
+extras_require_scram = [
+    'argon2_cffi',              # MIT license
+    'passlib',                  # BSD license
+]
+
 # everything
 extras_require_all = extras_require_twisted + extras_require_asyncio + \
     extras_require_accelerate + extras_require_compress + \
-    extras_require_serialization + extras_require_encryption
+    extras_require_serialization + extras_require_encryption + \
+    extras_require_scram
 
 # extras_require_all += extras_require_compress
 
@@ -197,6 +204,7 @@ setup(
         'compress': extras_require_compress,
         'serialization': extras_require_serialization,
         'encryption': extras_require_encryption,
+        'scram': extras_require_scram,
         'dev': extras_require_dev,
     },
     tests_require=test_requirements,

--- a/tox.ini
+++ b/tox.ini
@@ -55,6 +55,7 @@ deps =
 extras =
     encryption
     serialization
+    scram
 
 commands =
     sh -c "which python"


### PR DESCRIPTION
Continuation of https://github.com/crossbario/autobahn-python/pull/956

This adds an onWelcome/on_welcome hook for authenticators to use and SCRAM uses it to check the server-signature as well as a few other fixups. Now matches the draft-spec (again).