### PR TITLE
component fixups

### DIFF
--- a/autobahn/wamp/auth.py
+++ b/autobahn/wamp/auth.py
@@ -109,7 +109,7 @@ class AuthAnonymous(object):
             "on_challenge called on anonymous authentication"
         )
 
-    def on_welcome(self, msg):
+    def on_welcome(self, msg, authextra):
         return None
 
 
@@ -136,7 +136,7 @@ class AuthTicket(object):
         assert challenge.method == u"ticket"
         return self._ticket
 
-    def on_welcome(self, msg):
+    def on_welcome(self, msg, authextra):
         return None
 
 
@@ -187,7 +187,7 @@ class AuthCryptoSign(object):
     def on_challenge(self, session, challenge):
         return self._privkey.sign_challenge(session, challenge)
 
-    def on_welcome(self, msg):
+    def on_welcome(self, msg, authextra):
         return None
 
 

--- a/autobahn/wamp/component.py
+++ b/autobahn/wamp/component.py
@@ -362,7 +362,8 @@ class Component(ObservableMixin):
             self.on('join', do_registration)
         return decorator
 
-    def __init__(self, main=None, transports=None, config=None, realm=u'default', extra=None, authentication=None):
+    def __init__(self, main=None, transports=None, config=None, realm=u'default', extra=None,
+                 authentication=None, session_factory=None):
         """
         :param main: After a transport has been connected and a session
             has been established and joined to a realm, this (async)
@@ -401,6 +402,11 @@ class Component(ObservableMixin):
 
         :param authentication: configuration of authenticators
         :type authentication: dict mapping auth_type to dict
+
+        :param session_factory: if None, ``ApplicationSession`` is
+            used, otherwise a callable taking a single ``config`` argument
+            that is used to create a new `ApplicationSession` instance.
+        :type session_factory: callable
         """
         self.set_valid_events(
             [
@@ -415,8 +421,7 @@ class Component(ObservableMixin):
         )
 
         if main is not None and not callable(main):
-            raise RuntimeError('"main" must be a callable if given')
-
+            raise ValueError('"main" must be a callable if given')
         self._entry = main
 
         # use WAMP-over-WebSocket to localhost when no transport is specified at all
@@ -451,6 +456,8 @@ class Component(ObservableMixin):
         # XXX should have some checkconfig support
         self._authentication = authentication or {}
 
+        if session_factory:
+            self.session_factory = session_factory
         self._realm = realm
         self._extra = extra
 

--- a/autobahn/wamp/protocol.py
+++ b/autobahn/wamp/protocol.py
@@ -1648,7 +1648,8 @@ class _SessionShim(ApplicationSession):
         return authenticator.on_challenge(self, challenge)
 
     def onWelcome(self, msg):
-        if msg.authmethod is None:  # no authentication
+        if msg.authmethod is None or self._authenticators is None:
+            # no authentication
             return
         try:
             authenticator = self._authenticators[msg.authmethod]


### PR DESCRIPTION
This fixes some missing args in (some of) the new `on_welcome` handlers and add `session_factory=` as a convenience keyword arg for `Component` (instead of changing it right after construction).