### PR TITLE
Bytes kwargs

### DIFF
--- a/autobahn/wamp/message.py
+++ b/autobahn/wamp/message.py
@@ -278,6 +278,25 @@ def check_or_raise_extra(value, message=u"WAMP message invalid"):
     return value
 
 
+def _validate_kwargs(kwargs):
+    """
+    Internal helper. Takes a kwargs dict and either returns it, or a
+    new instance that has unicode keys.
+
+    This exists because u-msgpack will turn str() instances into bytes
+    in Python2, but if you used kwargs in 'the natural way', the dict
+    will contain str->whatever mappings and end up as bytes->whatever
+    on the other side (and if that side is Python3, it'll blow up if
+    you try to do **kwargs with the dict)
+    """
+    if kwargs is not None and six.PY2:
+        return {
+            unicode(k): v
+            for k, v in kwargs.iteritems()
+        }
+    return kwargs
+
+
 class Message(object):
     """
     WAMP message base class.
@@ -1312,7 +1331,7 @@ class Error(Message):
         self.request = request
         self.error = error
         self.args = args
-        self.kwargs = kwargs
+        self.kwargs = _validate_kwargs(kwargs)
         self.payload = payload
         self.enc_algo = enc_algo
         self.enc_key = enc_key
@@ -1593,7 +1612,7 @@ class Publish(Message):
         self.request = request
         self.topic = topic
         self.args = args
-        self.kwargs = kwargs
+        self.kwargs = _validate_kwargs(kwargs)
         self.payload = payload
         self.acknowledge = acknowledge
 
@@ -2402,7 +2421,7 @@ class Event(Message):
         self.subscription = subscription
         self.publication = publication
         self.args = args
-        self.kwargs = kwargs
+        self.kwargs = _validate_kwargs(kwargs)
         self.payload = payload
         self.publisher = publisher
         self.publisher_authid = publisher_authid
@@ -2745,7 +2764,7 @@ class Call(Message):
         self.request = request
         self.procedure = procedure
         self.args = args
-        self.kwargs = kwargs
+        self.kwargs = _validate_kwargs(kwargs)
         self.payload = payload
         self.timeout = timeout
         self.receive_progress = receive_progress
@@ -3061,7 +3080,7 @@ class Result(Message):
         Message.__init__(self)
         self.request = request
         self.args = args
-        self.kwargs = kwargs
+        self.kwargs = _validate_kwargs(kwargs)
         self.payload = payload
         self.progress = progress
 
@@ -3735,7 +3754,7 @@ class Invocation(Message):
         self.request = request
         self.registration = registration
         self.args = args
-        self.kwargs = kwargs
+        self.kwargs = _validate_kwargs(kwargs)
         self.payload = payload
         self.timeout = timeout
         self.receive_progress = receive_progress
@@ -4095,7 +4114,7 @@ class Yield(Message):
         Message.__init__(self)
         self.request = request
         self.args = args
-        self.kwargs = kwargs
+        self.kwargs = _validate_kwargs(kwargs)
         self.payload = payload
         self.progress = progress
         self.enc_algo = enc_algo

--- a/autobahn/wamp/protocol.py
+++ b/autobahn/wamp/protocol.py
@@ -673,7 +673,21 @@ class ApplicationSession(BaseSession):
                                 handler.fn, msg.subscription)
                             return self._swallow_error(e, errmsg)
 
-                        future = txaio.as_future(handler.fn, *invoke_args, **invoke_kwargs)
+                        try:
+                            future = txaio.as_future(handler.fn, *invoke_args, **invoke_kwargs)
+                        except TypeError:
+                            # if we have a python2 caller on the other end,
+                            # and they are using msgpack, and kwargs came from
+                            # a call like: call("foo", key="word") then the
+                            # 'key' will be a bytes here, so we convert .. and
+                            # just hope they were using utf8? (This is fixed
+                            # on the other end too, in marshal() in Call but
+                            # an older Autobahn could trigger it)
+                            str_invoke_kwargs = {
+                                k.decode('utf8'): v
+                                for k, v in invoke_kwargs.items()
+                            }
+                            future = txaio.as_future(handler.fn, *invoke_args, **str_invoke_kwargs)
                         txaio.add_callbacks(future, _success, _error)
 
                 else:
@@ -918,7 +932,21 @@ class ApplicationSession(BaseSession):
 
                                 invoke_kwargs[endpoint.details_arg] = types.CallDetails(registration, progress=progress, caller=msg.caller, caller_authid=msg.caller_authid, caller_authrole=msg.caller_authrole, procedure=proc, enc_algo=msg.enc_algo)
 
-                            on_reply = txaio.as_future(endpoint.fn, *invoke_args, **invoke_kwargs)
+                            try:
+                                on_reply = txaio.as_future(endpoint.fn, *invoke_args, **invoke_kwargs)
+                            except TypeError:
+                                # if we have a python2 caller on the other end,
+                                # and they are using msgpack, and kwargs came from
+                                # a call like: call("foo", key="word") then the
+                                # 'key' will be a bytes here, so we convert .. and
+                                # just hope they were using utf8? (This is fixed
+                                # on the other end too, in marshal() in Call but
+                                # an older Autobahn could trigger it)
+                                str_invoke_kwargs = {
+                                    k.decode('utf8'): v
+                                    for k, v in invoke_kwargs.items()
+                                }
+                                on_reply = txaio.as_future(endpoint.fn, *invoke_args, **str_invoke_kwargs)
 
                             def success(res):
                                 del self._invocations[msg.request]

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ Changelog
 master (unreleased)
 -------------------
 
+* fix: kwarg keys sometimes are bytes on Python2 (#980)
 * ...
 
 


### PR DESCRIPTION
If you have a Python2 caller, and it's using the msgpack serializer, it'll turn ``str`` instances into ``bytes`` -- and if you make a call like ``call(u"some.uri", arg0="value")`` then the ``arg0`` will be a ``str`` instance in the ``kwargs`` dict

However, if the callee is Python3, it also wants "str" instances when doing ``**kwargs`` but it'll instead have ``bytes`` keys. The "real" fix is the one in "message.py" but I also included the ``except TypeError`` code on the callee side to be a little more robust..