### PR TITLE
try forever to reconnect by default

### DIFF
--- a/autobahn/wamp/component.py
+++ b/autobahn/wamp/component.py
@@ -224,7 +224,7 @@ class _Transport(object):
     """
 
     def __init__(self, idx, kind, url, endpoint, serializers,
-                 max_retries=15,
+                 max_retries=-1,
                  max_retry_delay=300,
                  initial_retry_delay=1.5,
                  retry_delay_growth=1.5,

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ Changelog
 master (unreleased)
 -------------------
 
+* new: ``max_retries`` now defaults to -1 ("try forever")
 * ...
 
 

--- a/docs/wamp/programming.rst
+++ b/docs/wamp/programming.rst
@@ -211,7 +211,7 @@ Each transport is defined similarly to `"connecting transports" <https://crossba
 
 In addition, each transport may have some options related to re-connections:
 
-- ``max_retries``: (default 15) -1 means "try forever", or a hard limit.
+- ``max_retries``: (default -1, "try forever") or a hard limit.
 - ``max_retry_delay``: (default 300)
 - ``initial_retry_delay``: (default 1.5) how long we wait to re-connect the first time
 - ``retry_delay_growth``: (default 1.5) a multiplier expanding our delay each try (so the second re-connect we wait ``retry_delay_growth * initial_retry_delay`` seconds).


### PR DESCRIPTION
"Try 15 times" is a weird default for reconnecting, IMO. This is kind-of a "breaking change" but .... I think this leads to a better default experience.