### PR TITLE
implement abort argument in WebSocketAdapterProtocol._closeConnection

### DIFF
--- a/autobahn/asyncio/websocket.py
+++ b/autobahn/asyncio/websocket.py
@@ -121,9 +121,11 @@ class WebSocketAdapterProtocol(asyncio.Protocol):
         if not self.waiter.done():
             self.waiter.set_result(None)
 
-    # noinspection PyUnusedLocal
     def _closeConnection(self, abort=False):
-        self.transport.close()
+        if abort and hasattr(self.transport, 'abort'):
+            self.transport.abort()
+        else:
+            self.transport.close()
 
     def _onOpen(self):
         res = self.onOpen()


### PR DESCRIPTION
When connection was to be forcefully closed (for example due to failed ping), the `abort` argument of `WebSocketAdapterProtocol._closeConnection` was not honored. The connection was just closed regularly, and it usually took a few minutes, until a `RST` packet came from either side of the connection.

This pull requests fixes that by calling `abort` when asked to.