### PR TITLE
fixing broken link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ You can use **Autobahn\|Python** to create clients and servers in Python speakin
 
 **WebSocket** allows `bidirectional real-time messaging on the Web <http://crossbario.com/blog/post/websocket-why-what-can-i-use-it/>`__ and beyond, while `WAMP <http://wamp-proto.org/>`__ adds real-time application communication on top of WebSocket.
 
-**WAMP** provides asynchronous **Remote Procedure Calls** and **Publish & Subscribe** for applications in *one* protocol running over `WebSocket <http://tools.ietf.org/html/rfc6455>`__. WAMP is a *routed* protocol, so you need a **WAMP Router** to connect your **Autobahn\|Python** based clients. We provide `Crossbar.io <http://crossbar.io>`__, but there are `other options <http://wamp-proto.org/implementations/#routers>`__ as well.
+**WAMP** provides asynchronous **Remote Procedure Calls** and **Publish & Subscribe** for applications in *one* protocol running over `WebSocket <http://tools.ietf.org/html/rfc6455>`__. WAMP is a *routed* protocol, so you need a **WAMP Router** to connect your **Autobahn\|Python** based clients. We provide `Crossbar.io <http://crossbar.io>`__, but there are `other options <https://wamp-proto.org/implementations/index.html#routers>`__ as well.
 
 Features
 --------


### PR DESCRIPTION
https://wamp-proto.org/implementations/#routers does not work, use 
https://wamp-proto.org/implementations/index.html#routers