### PR TITLE
Fixed Python 3.7 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,6 +87,33 @@ matrix:
       - TOX_ENV=py36-asyncio
 
     #
+    # CPython 3.7
+    #
+    - python: 3.7
+      dist: xenial
+      sudo: required
+      env:
+      - TOX_ENV=py37-tw154
+
+    - python: 3.7
+      dist: xenial
+      sudo: required
+      env:
+      - TOX_ENV=py37-tw187
+
+    - python: 3.7
+      dist: xenial
+      sudo: required
+      env:
+      - TOX_ENV=py37-twtrunk
+
+    - python: 3.7
+      dist: xenial
+      sudo: required
+      env:
+      - TOX_ENV=py37-asyncio
+
+    #
     # PyPy3
     #
     - python: pypy

--- a/autobahn/asyncio/test/test_asyncio_websocket.py
+++ b/autobahn/asyncio/test/test_asyncio_websocket.py
@@ -23,14 +23,8 @@ import txaio
 class Test(TestCase):
 
     @pytest.mark.asyncio(forbid_global_loop=True)
-    def test_websocket_custom_loop(self):
-
-        def time_gen():
-            yield
-            yield
-
-        loop = AsyncioTestLoop(time_gen)
-        factory = WebSocketServerFactory(loop=loop)
+    def test_websocket_custom_loop(self, event_loop):
+        factory = WebSocketServerFactory(loop=event_loop)
         server = factory()
         transport = Mock()
 
@@ -79,10 +73,6 @@ class Test(TestCase):
             b'\r\n',  # last string doesn't get a \r\n from join()
         ])
         server.processHandshake()
-
-        import asyncio
-        from asyncio.test_utils import run_once
-        run_once(asyncio.get_event_loop())
 
         self.assertEqual(1, len(values))
         self.assertEqual(42 * 42, values[0])

--- a/autobahn/asyncio/test/test_asyncio_websocket.py
+++ b/autobahn/asyncio/test/test_asyncio_websocket.py
@@ -4,10 +4,6 @@ import sys
 
 # because py.test tries to collect it as a test-case
 try:
-    from asyncio.test_utils import TestLoop as AsyncioTestLoop
-except ImportError:
-    from trollius.test_utils import TestLoop as AsyncioTestLoop
-try:
     from unittest.mock import Mock
 except ImportError:
     from mock import Mock

--- a/autobahn/asyncio/websocket.py
+++ b/autobahn/asyncio/websocket.py
@@ -49,7 +49,7 @@ except ImportError:
 if hasattr(asyncio, 'ensure_future'):
     ensure_future = asyncio.ensure_future
 else:  # Deprecated since Python 3.4.4
-    ensure_future = asyncio.async
+    ensure_future = getattr(asyncio, 'async')
 
 __all__ = (
     'WebSocketServerProtocol',

--- a/tox.ini
+++ b/tox.ini
@@ -47,9 +47,9 @@ deps =
 
     py33-asyncio: pytest_asyncio<0.6
     py34-asyncio: pytest_asyncio<0.6
-    py35-asyncio: pytest_asyncio<0.6
-    py36-asyncio: pytest_asyncio<0.6
-    py37-asyncio: pytest_asyncio<0.6
+    py35-asyncio: pytest_asyncio
+    py36-asyncio: pytest_asyncio
+    py37-asyncio: pytest_asyncio
 
     ; aiohttp requires Python 3.4.2+
     ; py34-asyncio: pytest-aiohttp


### PR DESCRIPTION
Python 3.7 made "async" a keyword which caused a SyntaxError in the autobahn.asyncio.websocket module. This patch (by @Ardonius) fixes that.
This also removes imports of undocumented asyncio test modules that were removed in Python 3.7 which caused tests to fail.

Fixes #1022.