### PR TITLE
Fix auto-reconnect in case of WS handshake failure

### DIFF
--- a/autobahn/asyncio/component.py
+++ b/autobahn/asyncio/component.py
@@ -269,7 +269,7 @@ class Component(component.Component):
                 server_hostname=tls_hostname,
             )
             time_f = asyncio.ensure_future(asyncio.wait_for(f, timeout=timeout))
-            return time_f
+            return self._wrap_connection_future(time_f)
 
         elif transport.endpoint[u'type'] == u'unix':
             path = transport.endpoint[u'path']
@@ -280,10 +280,29 @@ class Component(component.Component):
                 path=path,
             )
             time_f = asyncio.ensure_future(asyncio.wait_for(f, timeout=timeout))
-            return time_f
+            return self._wrap_connection_future(time_f)
 
         else:
             assert(False), 'should not arrive here'
+
+
+    # The result of asyncio's AbstractEventLoop.create_connection() and 
+    # AbstractEventLoop.create_unix_connection() is a (transport, protocol) pair, 
+    # while in the Twisted counterpart, the IStreamClientEndpoint.connect() method 
+    # only returns a protocol object. We need to reconcile the two, since the
+    # the transport connection success callback in wamp.component expects only the protocol
+    def _wrap_connection_future(self, conn):
+        f = txaio.create_future()
+
+        def on_success(result):
+            (transport, proto) = result
+            txaio.resolve(f, proto)
+        
+        def on_failure(err):
+            txaio.reject(f, err)
+
+        txaio.add_callbacks(conn, on_success, on_failure)
+        return f
 
     # async function
     def start(self, loop=None):

--- a/autobahn/asyncio/component.py
+++ b/autobahn/asyncio/component.py
@@ -285,19 +285,20 @@ class Component(component.Component):
         else:
             assert(False), 'should not arrive here'
 
-
-    # The result of asyncio's AbstractEventLoop.create_connection() and 
-    # AbstractEventLoop.create_unix_connection() is a (transport, protocol) pair, 
-    # while in the Twisted counterpart, the IStreamClientEndpoint.connect() method 
-    # only returns a protocol object. We need to reconcile the two, since the
-    # the transport connection success callback in wamp.component expects only the protocol
     def _wrap_connection_future(self, conn):
+
+        # The result of asyncio's AbstractEventLoop.create_connection() and
+        # AbstractEventLoop.create_unix_connection() is a (transport, protocol) pair,
+        # while in the Twisted counterpart, the IStreamClientEndpoint.connect() method
+        # only returns a protocol object. We need to reconcile the two, since the
+        # the transport connection success callback in wamp.component expects only the protocol
+
         f = txaio.create_future()
 
         def on_success(result):
             (transport, proto) = result
             txaio.resolve(f, proto)
-        
+
         def on_failure(err):
             txaio.reject(f, err)
 

--- a/autobahn/asyncio/websocket.py
+++ b/autobahn/asyncio/websocket.py
@@ -96,11 +96,10 @@ class WebSocketAdapterProtocol(asyncio.Protocol):
 
         self._connectionMade()
 
-
     def connection_lost(self, exc):
         self.connectionLost(exc)
 
-    #keep naming consistent with the corresponding function in twisted/websocket.py
+    # keep naming consistent with the corresponding function in twisted/websocket.py
     def connectionLost(self, exc):
         self._connectionLost(exc)
         # according to asyncio docs, connection_lost(None) is called

--- a/autobahn/asyncio/websocket.py
+++ b/autobahn/asyncio/websocket.py
@@ -96,7 +96,12 @@ class WebSocketAdapterProtocol(asyncio.Protocol):
 
         self._connectionMade()
 
+
     def connection_lost(self, exc):
+        self.connectionLost(exc)
+
+    #keep naming consistent with the corresponding function in twisted/websocket.py
+    def connectionLost(self, exc):
         self._connectionLost(exc)
         # according to asyncio docs, connection_lost(None) is called
         # if something else called transport.close()

--- a/autobahn/wamp/component.py
+++ b/autobahn/wamp/component.py
@@ -726,7 +726,7 @@ class Component(ObservableMixin):
         d = self._connect_transport(reactor, transport, create_session)
 
         def on_connect_sucess(proto):
-                        
+
             # if e.g. an SSL handshake fails, we will have
             # successfully connected (i.e. get here) but need to
             # 'listen' for the "connectionLost" from the underlying

--- a/autobahn/wamp/component.py
+++ b/autobahn/wamp/component.py
@@ -725,10 +725,8 @@ class Component(ObservableMixin):
 
         d = self._connect_transport(reactor, transport, create_session)
 
-        def on_connect_sucess(result):
-            # the result of AbstractEventLoop.create_connection() is a (transport, protocol) pair
-            (transport, proto) = result
-
+        def on_connect_sucess(proto):
+                        
             # if e.g. an SSL handshake fails, we will have
             # successfully connected (i.e. get here) but need to
             # 'listen' for the "connectionLost" from the underlying

--- a/autobahn/wamp/component.py
+++ b/autobahn/wamp/component.py
@@ -37,7 +37,7 @@ import txaio
 from autobahn.util import ObservableMixin
 from autobahn.websocket.util import parse_url
 from autobahn.wamp.types import ComponentConfig, SubscribeOptions, RegisterOptions
-from autobahn.wamp.exception import SessionNotReady, ApplicationError
+from autobahn.wamp.exception import SessionNotReady, ApplicationError, TransportLost
 from autobahn.wamp.auth import create_authenticator, IAuthenticator
 
 
@@ -725,7 +725,10 @@ class Component(ObservableMixin):
 
         d = self._connect_transport(reactor, transport, create_session)
 
-        def on_connect_sucess(proto):
+        def on_connect_sucess(result):
+            # the result of AbstractEventLoop.create_connection() is a (transport, protocol) pair
+            (transport, proto) = result
+
             # if e.g. an SSL handshake fails, we will have
             # successfully connected (i.e. get here) but need to
             # 'listen' for the "connectionLost" from the underlying
@@ -738,7 +741,9 @@ class Component(ObservableMixin):
             def lost(fail):
                 rtn = orig(fail)
                 if not txaio.is_called(done):
-                    txaio.reject(done, fail)
+                    # we must wrap the failure reason (can be None) in an actual
+                    # Wamp exception
+                    txaio.reject(done, TransportLost(fail))
                 return rtn
             proto.connectionLost = lost
 


### PR DESCRIPTION
When using the component API with asyncio, the client component doesn't try to reconnect after a failing WS handshake, as pointed out in issues #1010 and #1030. 

The issue is caused by some naming mismatch between the twisted and asyncio implementations of the `WebSocketAdapterProtocol` class. In particular the wamp component (wamp/component.py) tries to wrap the `connectionLost()` method of the underlying protocol, but the asyncio implementation only has a `connection_lost()` method. 

Curiously enough, the affected code path doesn't seem to be invoked when using the twisted counterpart.

This PR aims at fixing these issues, enabling the component to proceed with the usual exponential backoff retry mechanism when failing to properly connect to the other endpoint. 