### PR TITLE
Fix asyncio auto-reconnect in case of WS handshake failure

### DIFF
--- a/autobahn/asyncio/websocket.py
+++ b/autobahn/asyncio/websocket.py
@@ -97,6 +97,10 @@ class WebSocketAdapterProtocol(asyncio.Protocol):
         self._connectionMade()
 
     def connection_lost(self, exc):
+        self.connectionLost(exc)
+
+    # keep naming consistent with the corresponding function in twisted/websocket.py
+    def connectionLost(self, exc):
         self._connectionLost(exc)
         # according to asyncio docs, connection_lost(None) is called
         # if something else called transport.close()


### PR DESCRIPTION
This PR is a new take on https://github.com/crossbario/autobahn-python/pull/1034, which was closed without further comments.

The PR fixes the way the asyncio component handles the failure to connect to the other endpoint, as reported in issues #1010 and #1030.

In particular it fixes:
* a method naming mismatch (`connection_lost` vs `connectionLost`) in autobahn/asyncio/websocket.py
* an argument type mismatch in the chaining of asyncio connection success callbacks (see autobahn/asyncio/component.py)
* the need transform the 'loss of connection' exception (which could be None), before passing it to upper layers (where the exception cannot be None)
