### PR TITLE
Bring "cancel" up to spec

### DIFF
--- a/autobahn/wamp/message.py
+++ b/autobahn/wamp/message.py
@@ -2938,9 +2938,12 @@ class Cancel(Message):
     """
 
     SKIP = u'skip'
-    ABORT = u'abort'
     KILL = u'kill'
     KILLNOWAIT = u'killnowait'
+
+    @property
+    def ABORT(self):
+        return self.KILLNOWAIT
 
     __slots__ = (
         'request',
@@ -2953,12 +2956,12 @@ class Cancel(Message):
         :param request: The WAMP request ID of the original `CALL` to cancel.
         :type request: int
 
-        :param mode: Specifies how to cancel the call (``"skip"``, ``"abort"`` or ``"kill"``).
+        :param mode: Specifies how to cancel the call (``"skip"``, ``"killnowait"`` or ``"kill"``).
         :type mode: str or None
         """
         assert(type(request) in six.integer_types)
         assert(mode is None or type(mode) == six.text_type)
-        assert(mode in [None, self.SKIP, self.ABORT, self.KILL])
+        assert(mode in [None, self.SKIP, self.KILLNOWAIT, self.KILL])
 
         Message.__init__(self)
         self.request = request
@@ -2993,7 +2996,7 @@ class Cancel(Message):
             if type(option_mode) != six.text_type:
                 raise ProtocolError("invalid type {0} for 'mode' option in CANCEL".format(type(option_mode)))
 
-            if option_mode not in [Cancel.SKIP, Cancel.ABORT, Cancel.KILL]:
+            if option_mode not in [Cancel.SKIP, Cancel.KILLNOWAIT, Cancel.KILL]:
                 raise ProtocolError("invalid value '{0}' for 'mode' option in CANCEL".format(option_mode))
 
             mode = option_mode
@@ -3975,9 +3978,12 @@ class Interrupt(Message):
     The WAMP message code for this type of message.
     """
 
-    ABORT = u'abort'
     KILL = u'kill'
     KILLNOWAIT = u'killnowait'
+
+    @property
+    def ABORT(self):
+        return self.KILLNOWAIT
 
     __slots__ = (
         'request',
@@ -3990,12 +3996,12 @@ class Interrupt(Message):
         :param request: The WAMP request ID of the original ``INVOCATION`` to interrupt.
         :type request: int
 
-        :param mode: Specifies how to interrupt the invocation (``"abort"`` or ``"kill"``).
+        :param mode: Specifies how to interrupt the invocation (``"killnowait"`` or ``"kill"``).
         :type mode: str or None
         """
         assert(type(request) in six.integer_types)
         assert(mode is None or type(mode) == six.text_type)
-        assert(mode is None or mode in [self.ABORT, self.KILL])
+        assert(mode is None or mode in [self.KILL, self.KILLNOWAIT])
 
         Message.__init__(self)
         self.request = request
@@ -4030,7 +4036,7 @@ class Interrupt(Message):
             if type(option_mode) != six.text_type:
                 raise ProtocolError("invalid type {0} for 'mode' option in INTERRUPT".format(type(option_mode)))
 
-            if option_mode not in [Interrupt.ABORT, Interrupt.KILL]:
+            if option_mode not in [Interrupt.KILL, Interrupt.KILLNOWAIT]:
                 raise ProtocolError("invalid value '{0}' for 'mode' option in INTERRUPT".format(option_mode))
 
             mode = option_mode

--- a/autobahn/wamp/message.py
+++ b/autobahn/wamp/message.py
@@ -2940,6 +2940,7 @@ class Cancel(Message):
     SKIP = u'skip'
     ABORT = u'abort'
     KILL = u'kill'
+    KILLNOWAIT = u'killnowait'
 
     __slots__ = (
         'request',
@@ -3976,6 +3977,7 @@ class Interrupt(Message):
 
     ABORT = u'abort'
     KILL = u'kill'
+    KILLNOWAIT = u'killnowait'
 
     __slots__ = (
         'request',

--- a/autobahn/wamp/protocol.py
+++ b/autobahn/wamp/protocol.py
@@ -1109,7 +1109,8 @@ class ApplicationSession(BaseSession):
                     on_reply = self._unregister_reqs.pop(msg.request).on_reply
 
                 if on_reply:
-                    txaio.reject(on_reply, self._exception_from_message(msg))
+                    if not txaio.is_called(on_reply):
+                        txaio.reject(on_reply, self._exception_from_message(msg))
                 else:
                     raise ProtocolError("WampAppSession.onMessage(): ERROR received for non-pending request_type {0} and request ID {1}".format(msg.request_type, msg.request))
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,10 @@ Changelog
 master
 ------
 
+* fix: Cancel and Interrupt gets ``"killnowait"`` mode
+* new: Cancel and Interrupt do not have ``ABORT/"abort"`` (there is
+  backwards-compatibility wrapper so code using ``Cancel.ABORT`` will
+  end up using ``killnowait`` on the wire instead).
 * ...
 
 


### PR DESCRIPTION
This adds "killnowait", and some backwards-compatibility for "abort" -- a different PR shortly with no backwards-compatibiltiy code (take your pick :).