### PR TITLE
Fixed typo on class name

### DIFF
--- a/examples/asyncio/wamp/overview/backend.py
+++ b/examples/asyncio/wamp/overview/backend.py
@@ -3,7 +3,7 @@ import asyncio
 from autobahn.asyncio.wamp import ApplicationSession, ApplicationRunner
 
 
-class MyComponent(ApplicationSession):
+class Component(ApplicationSession):
     async def onJoin(self, details):
         # a remote procedure; see frontend.py for a Python front-end
         # that calls this. Any language with WAMP bindings can now call

--- a/examples/asyncio/wamp/overview/frontend.py
+++ b/examples/asyncio/wamp/overview/frontend.py
@@ -3,7 +3,7 @@ import asyncio
 from autobahn.asyncio.wamp import ApplicationSession, ApplicationRunner
 
 
-class MyComponent(ApplicationSession):
+class Component(ApplicationSession):
     async def onJoin(self, details):
         # listening for the corresponding message from the "backend"
         # (any session that .publish()es to this topic).


### PR DESCRIPTION
Fixed typo in examples/asyncio/wamp/overview.