### PR TITLE
Fixed DeprecationWarnings caused by invalid escape sequences

### DIFF
--- a/autobahn/util.py
+++ b/autobahn/util.py
@@ -712,7 +712,7 @@ def wildcards2patterns(wildcards):
     # match. Without this, e.g. a prefix will match:
     # re.match('.*good\\.com', 'good.com.evil.com')  # match!
     # re.match('.*good\\.com$', 'good.com.evil.com') # no match!
-    return [re.compile('^' + wc.replace('.', '\.').replace('*', '.*') + '$') for wc in wildcards]
+    return [re.compile('^' + wc.replace('.', r'\.').replace('*', '.*') + '$') for wc in wildcards]
 
 
 class ObservableMixin(object):

--- a/autobahn/wamp/uri.py
+++ b/autobahn/wamp/uri.py
@@ -208,7 +208,7 @@ class Pattern(object):
 
             if component == '':
                 group_count += 1
-                pl.append("([a-z0-9][a-z0-9_\-]*)")
+                pl.append(r"([a-z0-9][a-z0-9_\-]*)")
                 nc[group_count] = str
                 continue
 
@@ -217,7 +217,7 @@ class Pattern(object):
         if nc:
             # URI pattern
             self._type = Pattern.URI_TYPE_WILDCARD
-            p = "^" + "\.".join(pl) + "$"
+            p = "^" + r"\.".join(pl) + "$"
             self._pattern = re.compile(p)
             self._names = nc
         else:


### PR DESCRIPTION
These warnings are only emitted on Python 3.7.