### PR TITLE
component.stop() should not return session.leave() result (if session exists)

### DIFF
--- a/autobahn/wamp/component.py
+++ b/autobahn/wamp/component.py
@@ -655,7 +655,7 @@ class Component(ObservableMixin):
     def stop(self):
         self._stopping = True
         if self._session and self._session.is_attached():
-            return self._session.leave()
+            self._session.leave()
         elif self._delay_f:
             # This cancel request will actually call the "error" callback of
             # the _delay_f future. Nothing to worry about.


### PR DESCRIPTION
In component.py the stop() should do session.leave() and return the a future object if session exists (not return session.leave() result only).

Otherwise we are not able to call again the component.start(...) method after stop() method called.