### PR TITLE
Revert "component.stop() should not return session.leave() result (if session exists)"

### DIFF
--- a/autobahn/wamp/component.py
+++ b/autobahn/wamp/component.py
@@ -668,7 +668,7 @@ class Component(ObservableMixin):
     def stop(self):
         self._stopping = True
         if self._session and self._session.is_attached():
-            self._session.leave()
+            return self._session.leave()
         elif self._delay_f:
             # This cancel request will actually call the "error" callback of
             # the _delay_f future. Nothing to worry about.


### PR DESCRIPTION
Reverts crossbario/autobahn-python#1075