### PR TITLE
Added parameter `dumps_default` to JsonObjectSerializer.__init__

### DIFF
--- a/autobahn/wamp/serializer.py
+++ b/autobahn/wamp/serializer.py
@@ -223,7 +223,7 @@ class JsonObjectSerializer(object):
         :param batched: Flag that controls whether serializer operates in batched mode.
         :type batched: bool
 
-        :param dumps_default: Function that gets called for objects that can’t otherwise be serialized to JSON
+        :param dumps_default: Function that gets called for objects that can't otherwise be serialized to JSON
         :type dumps_default: callable
         """
         self._batched = batched
@@ -285,7 +285,7 @@ class JsonSerializer(Serializer):
         :param batched: Flag to control whether to put this serialized into batched mode.
         :type batched: bool
 
-        :param dumps_default: Function that gets called for objects that can’t otherwise be serialized to JSON
+        :param dumps_default: Function that gets called for objects that can't otherwise be serialized to JSON
         :type dumps_default: callable
         """
         Serializer.__init__(self, JsonObjectSerializer(batched=batched, dumps_default=dumps_default))


### PR DESCRIPTION
Autobahn-python current implementation does not allow to serialize to JSON non standard types of value in WAMP message kwargs/args (eg. `kwargs={'amount': decimal.Decimal('10.25')}`).

I added parameter `dumps_default` to `JsonObjectSerializer.__init__` in order to allow customize JSON dumping of non-standard types.

Thanks to this change we will be able to do the following:

```python
def dumps_default(obj):
    if isinstance(obj, decimal.Decimal):
        return str(obj)
    raise TypeError('Unable to convert object of {} to JSON'.format(type(obj)))

serializers = [JsonSerializer(dumps_default=dumps_default)]
server = WampRawSocketServerFactory(factory, serializers)
```