### PR TITLE
Allow optional activation_code to be passed in "authextra"

### DIFF
--- a/autobahn/wamp/auth.py
+++ b/autobahn/wamp/auth.py
@@ -148,6 +148,7 @@ class AuthCryptoSign(object):
 
     def __init__(self, **kw):
         # should put in checkconfig or similar
+
         for key in kw.keys():
             if key not in [u'authextra', u'authid', u'authrole', u'privkey']:
                 raise ValueError(
@@ -159,11 +160,12 @@ class AuthCryptoSign(object):
                     "Must provide '{}' for cryptosign".format(key)
                 )
         for key in kw.get('authextra', dict()):
-            if key not in [u'pubkey']:
+            if key not in [u'pubkey', u'activation_code']:
                 raise ValueError(
                     "Unexpected key '{}' in 'authextra'".format(key)
                 )
 
+        activation_code = kw.get('authextra', {}).get('activation_code')
         from autobahn.wamp.cryptosign import SigningKey
         self._privkey = SigningKey.from_key_bytes(
             binascii.a2b_hex(kw[u'privkey'])
@@ -178,6 +180,10 @@ class AuthCryptoSign(object):
         else:
             kw[u'authextra'] = kw.get(u'authextra', dict())
             kw[u'authextra'][u'pubkey'] = self._privkey.public_key()
+
+        if activation_code:
+            kw[u'authextra'][u'activation_code'] = activation_code
+
         self._args = kw
 
     @property


### PR DESCRIPTION
I've been playing with a Python version of the UI's network discovery code and started it as a WAMP client using the Component class. (I know, I don't need to use Cryptosign for this, but it seemed like a useful exercise to see how it would work) .. I came unstuck when needing to pass an activation code, this addresses the issue. My code looks like this;
```python
        self._key = SigningKey.from_key_bytes(binascii.a2b_hex(PRIVATEKEY))
        extra = {u'pubkey': self._key.public_key(), u'activation_code': ACTIVE }
        self.privkey_hex = self._key._key.encode(encoder=HexEncoder)
        authenticator = create_authenticator(
            u"cryptosign",
            authid=AUTHID,
            authrole='user' if realm == 'com.crossbario.fabric' else 'owner',
            privkey=self.privkey_hex,
            authextra=extra
        )
        self._component = Component(
            transports=[{'url': self._url}],
            realm=realm,
            authentication={'cryptosign': authenticator}
        )
```
Which works with this patch .. without it, I'm not sure how I can apply an activation code with component level cryptosign authentication. (in reality, the activation code is only ever passed on the second run through, first pass generates the activation code request, third and subsequent passes are fully verified)