### PR TITLE
Make default realm name to be in synergy with crossbar

### DIFF
--- a/autobahn/wamp/component.py
+++ b/autobahn/wamp/component.py
@@ -407,7 +407,7 @@ class Component(ObservableMixin):
             return fn
         return decorator
 
-    def __init__(self, main=None, transports=None, config=None, realm=u'default', extra=None,
+    def __init__(self, main=None, transports=None, config=None, realm=u'realm1', extra=None,
                  authentication=None, session_factory=None, is_fatal=None):
         """
         :param main: After a transport has been connected and a session

--- a/autobahn/wamp/protocol.py
+++ b/autobahn/wamp/protocol.py
@@ -289,7 +289,7 @@ class ApplicationSession(BaseSession):
         Implements :func:`autobahn.wamp.interfaces.ISession`
         """
         BaseSession.__init__(self)
-        self.config = config or types.ComponentConfig(realm=u"default")
+        self.config = config or types.ComponentConfig(realm=u"realm1")
 
         # set client role features supported and announced
         self._session_roles = role.DEFAULT_CLIENT_ROLES
@@ -1789,7 +1789,7 @@ class ApplicationSessionFactory(object):
         :param config: The default component configuration.
         :type config: instance of :class:`autobahn.wamp.types.ComponentConfig`
         """
-        self.config = config or types.ComponentConfig(realm=u"default")
+        self.config = config or types.ComponentConfig(realm=u"realm1")
 
     def __call__(self):
         """


### PR DESCRIPTION
The config created with `crossbar init` has the default realm named 'realm1', autobahn-python should also use the same name.

I will work on something similar for autobahn-java as well.