### PR TITLE
[1118] skipping Yield message if transport gets closed before success callback is called

### DIFF
--- a/autobahn/wamp/protocol.py
+++ b/autobahn/wamp/protocol.py
@@ -973,6 +973,10 @@ class ApplicationSession(BaseSession):
                                         reply = message.Yield(msg.request,
                                                               args=[res])
 
+                                if self._transport is None:
+                                    self.log.debug('Skipping result of "{}", request {} because transport disconnected.'.format(registration.procedure, msg.request))
+                                    return
+
                                 try:
                                     self._transport.send(reply)
                                 except SerializationError as e:


### PR DESCRIPTION
fixes first issue from #1118