### PR TITLE
Add on_error callback for application code

### DIFF
--- a/autobahn/wamp/component.py
+++ b/autobahn/wamp/component.py
@@ -466,6 +466,7 @@ class Component(ObservableMixin):
                 'leave',        # fired by ApplicationSession
                 'disconnect',   # fired by ApplicationSession
                 'connectfailure',   # fired by base class
+                'error'
             ]
         )
 
@@ -669,6 +670,7 @@ class Component(ObservableMixin):
 
             if not self._can_reconnect():
                 err_msg = u"Component failed: Exhausted all transport connect attempts"
+                self.fire('error', err_msg)
                 self.log.info(err_msg)
                 try:
                     raise RuntimeError(err_msg)
@@ -879,6 +881,11 @@ class Component(ObservableMixin):
         """
         self.on('ready', fn)
 
+    def on_error(self, fn):
+        """
+        A decorator as a shortcut for listening for 'ready' events.
+        """
+        self.on('error', fn)
 
 def _run(reactor, components, done_callback):
     """


### PR DESCRIPTION
What I want to achieve with this PR is giving application code a way to react to `Component failed: Exhausted all transport connect attempts`. Currently I couldn't find an appropriate way to terminate the execution when it happens. 

Open to discussion and hints. 