### PR TITLE
Add 'run' function to __all__ of the component API modules

### DIFF
--- a/autobahn/asyncio/component.py
+++ b/autobahn/asyncio/component.py
@@ -52,7 +52,7 @@ from autobahn.asyncio.wamp import Session
 from autobahn.wamp.serializer import create_transport_serializers, create_transport_serializer
 
 
-__all__ = ('Component',)
+__all__ = ('Component', 'run')
 
 
 def _unique_list(seq):

--- a/autobahn/twisted/component.py
+++ b/autobahn/twisted/component.py
@@ -57,7 +57,7 @@ from autobahn.wamp import component
 from autobahn.twisted.wamp import Session
 from autobahn.wamp.serializer import create_transport_serializers, create_transport_serializer
 
-__all__ = ('Component',)
+__all__ = ('Component', 'run')
 
 
 def _unique_list(seq):


### PR DESCRIPTION
My IDE complaints about 'run' not being `__all__`  ![complaint](https://user-images.githubusercontent.com/6350837/54497206-938cd080-4919-11e9-8964-63d7505471d2.png) 

From what I know, `__all__` contains symbols of a module that we deem public, "officially" it's defines what gets imported by `from module import *` 
