### PR TITLE
CLI client

### DIFF
--- a/autobahn/__main__.py
+++ b/autobahn/__main__.py
@@ -328,7 +328,7 @@ async def do_subscribe(reactor, session, options):
     await all_done
 
 
-def main():
+def _main():
     react(
         lambda reactor: ensureDeferred(
             _real_main(reactor)

--- a/autobahn/__main__.py
+++ b/autobahn/__main__.py
@@ -329,13 +329,21 @@ async def do_subscribe(reactor, session, options):
 
 
 def _main():
+    """
+    This is a magic name for `python -m autobahn`, and specified as
+    our entry_point in setup.py
+    """
     react(
         lambda reactor: ensureDeferred(
             _real_main(reactor)
         )
     )
 
+
 async def _real_main(reactor):
+    """
+    Sanity check options, create a connection and run our subcommand
+    """
     options = top.parse_args()
     component = _create_component(options)
 

--- a/autobahn/__main__.py
+++ b/autobahn/__main__.py
@@ -1,0 +1,141 @@
+###############################################################################
+#
+# The MIT License (MIT)
+#
+# Copyright (c) Crossbar.io Technologies GmbH
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+###############################################################################
+
+from __future__ import absolute_import
+
+# this module is available as the 'wamp' command-line tool or as
+# 'python -m autobahn'
+
+import sys
+import argparse
+
+from autobahn.twisted.component import Component, run
+from autobahn.wamp.exception import ApplicationError
+
+
+## XXX how to find connection config?
+# - if there's a .crossbar/ here, load .crossbar/config.{json,yaml}
+#   and connect to any transport ('--transport-id X' on the cli?)
+# - cli options
+# - read a config.json from stdin, make all transports available by name/id?
+
+# wamp [options] {call,publish,subscribe,register} wamp-uri args --keywords kwargs
+# all kwargs are "some-arg=thevalue" following a --keywords
+
+
+top = argparse.ArgumentParser(prog="wamp")
+top.add_argument(
+    '--url',
+    action='store',
+    help='A WAMP URL to connect to, like ws://127.0.0.1:8080/ws or rs://localhost:1234/',
+    required=True,
+)
+top.add_argument(
+    '--realm', '-r',
+    action='store',
+    help='The realm to join',
+    default='default',
+)
+sub = top.add_subparsers(
+    title="subcommands",
+    dest="subcommand_name",
+#    help="ohai what goes here?",
+)
+
+call = sub.add_parser(
+    'call',
+    help='Do a WAMP call() and print any results',
+)
+call.add_argument(
+    'uri',
+    type=str,
+    help="A WAMP URI to call"
+)
+call.add_argument(
+    'call_args',
+    nargs='*',
+    help="All additional arguments are positional args (HOWTO do kwargs?)",
+)
+# XXX FIXME: can do like "wamp call pos0 pos1 --kw name value --kw name value pos2"
+
+
+def _create_component(options):
+    if options.url.startswith('ws://'):
+        kind = 'websocket'
+    elif options.url.startswith('rs://'):
+        kind = 'rawsocket'
+    else:
+        raise ValueError(
+            "URL should start with ws:// or rs://"
+        )
+    return Component(
+        transports=[{
+            "type": kind,
+            "url": options.url,
+        }],
+        authentication={
+            "cryptosign": {
+                "authid": "wheel_pusher",
+                "authrole": "wheel_pusher",
+                "privkey": "4778956c24819ac2765fbe2e7d38b798f59d0d96931d519d70c36b5889e43a7e",
+            }
+        },
+        realm=options.realm,
+    )
+
+
+def _main():
+    options = top.parse_args()
+    component = _create_component(options)
+
+    if options.subcommand_name is None:
+        print("Must select a subcommand")
+        sys.exit(1)
+
+    exit_code = [0]
+
+    if options.subcommand_name == 'call':
+        call_args = list(options.call_args)
+        call_kwargs = dict()
+
+        @component.on_join
+        async def _(session, details):
+            print(f"connected: authrole={details.authrole}")
+            try:
+                results = await session.call(options.uri, *call_args, **call_kwargs)
+                print("result: {}".format(results))
+            except ApplicationError as e:
+                print("\n{}: {}\n".format(e.error, ''.join(e.args)))
+                exit_code[0] = 5
+            await session.leave()
+
+    run([component])
+    print("hi")
+    sys.exit(exit_code[0])
+
+
+if __name__ == "__main__":
+    _main()

--- a/autobahn/__main__.py
+++ b/autobahn/__main__.py
@@ -43,18 +43,17 @@ except ImportError:
     sys.exit(1)
 
 from twisted.internet.defer import Deferred, ensureDeferred
-from twisted.internet.task import react, deferLater
+from twisted.internet.task import react
 from twisted.internet.protocol import ProcessProtocol
 
 from autobahn.wamp.exception import ApplicationError
 from autobahn.wamp.types import PublishOptions
-from autobahn.wamp.types import RegisterOptions
 from autobahn.wamp.types import SubscribeOptions
 
 
-## XXX other ideas to get 'connection config':
-## - if there .crossbar/ here, load that config and accept a --name or
-##   so to idicate which transport to use
+# XXX other ideas to get 'connection config':
+# - if there .crossbar/ here, load that config and accept a --name or
+#   so to idicate which transport to use
 
 # wamp [options] {call,publish,subscribe,register} wamp-uri [args] [kwargs]
 #
@@ -96,7 +95,6 @@ top.add_argument(
 sub = top.add_subparsers(
     title="subcommands",
     dest="subcommand_name",
-#    help="ohai what goes here?",
 )
 
 
@@ -211,14 +209,14 @@ def _create_component(options):
 
     authentication = dict()
     if options.private_key:
-        if not options.authid:# or not options.authrole:
+        if not options.authid:
             raise ValueError(
                 "Require --authid and --authrole if --private-key (or WAMP_PRIVATE_KEY) is provided"
             )
         authentication["cryptosign"] = {
-                "authid": options.authid,
-                "authrole": options.authrole,
-                "privkey": options.private_key,
+            "authid": options.authid,
+            "authrole": options.authrole,
+            "privkey": options.private_key,
         }
 
     return Component(
@@ -300,7 +298,7 @@ async def do_register(reactor, session, options):
             if countdown[0] <= 0:
                 reactor.callLater(0, all_done.callback, None)
 
-    reg = await session.register(called, options.uri)
+    await session.register(called, options.uri)
     await all_done
 
 
@@ -324,7 +322,7 @@ async def do_subscribe(reactor, session, options):
             if countdown[0] <= 0:
                 reactor.callLater(0, all_done.callback, None)
 
-    reg = await session.subscribe(published, options.uri, options=SubscribeOptions(match=options.match))
+    await session.subscribe(published, options.uri, options=SubscribeOptions(match=options.match))
     await all_done
 
 

--- a/autobahn/twisted/component.py
+++ b/autobahn/twisted/component.py
@@ -182,7 +182,19 @@ def _create_transport_endpoint(reactor, endpoint_config):
 
             # create a non-TLS connecting TCP socket
             else:
-                if version == 4:
+                if host.endswith(".onion"):
+                    # hmm, can't log here?
+                    # self.log.info("{host} appears to be a Tor endpoint", host=host)
+                    try:
+                        import txtorcon
+                        endpoint = txtorcon.TorClientEndpoint(host, port)
+                    except ImportError:
+                        raise RuntimeError(
+                            "{} appears to be a Tor Onion service, but txtorcon is not installed".format(
+                                host,
+                            )
+                        )
+                elif version == 4:
                     endpoint = TCP4ClientEndpoint(reactor, host, port, timeout=timeout)
                 elif version == 6:
                     try:

--- a/setup.py
+++ b/setup.py
@@ -265,7 +265,7 @@ setup(
 
     entry_points={
         "console_scripts": [
-            "wamp = autobahn.__main__:main",
+            "wamp = autobahn.__main__:_main",
         ]
     },
 

--- a/setup.py
+++ b/setup.py
@@ -265,7 +265,7 @@ setup(
 
     entry_points={
         "console_scripts": [
-            "wamp = autobahn.__main__:_main",
+            "wamp = autobahn.__main__:main",
         ]
     },
 

--- a/setup.py
+++ b/setup.py
@@ -263,6 +263,12 @@ setup(
     package_data={'autobahn.asyncio': ['test/*']},
     cffi_modules=cffi_modules,
 
+    entry_points={
+        "console_scripts": [
+            "wamp = autobahn.__main__:_main",
+        ]
+    },
+
     # this flag will make files from MANIFEST.in go into _source_ distributions only
     include_package_data=True,
 


### PR DESCRIPTION
This adds a cli client, available as `wamp` or `python -m autobahn`. It supports `cryptosign` authentication (only, so far) and connects to websocket endpoints via their URL. For authentication, you can set the environment variable `WAMP_PRIVATE_KEY` to the hex-encoded private key (or use `--private-key`) Examples:

```
wamp --authid foo --url ws://localhost:8080/ws --realm default subscribe some.topic
wamp --authid foo --url ws://localhost:8080/ws --realm default publish some.topic arg0 arg1 --keyword foo bar
```

Every time the second command is run, the subscriber process will print out received events, one per line. Something like:

```{"args": ["arg0", "arg1"], "kwargs": {"foo": "bar}}```

The `call` / `register` variants are very similar, except the `register` calls a specified sub-command instead of printing out the received event. It passes in the args via environment variables: `WAMP_ARGS` and/or `WAMP_KWARGS` and/or `WAMP_ARGS_JSON` (a list of strings) and/or `WAMP_KWARGS_JSON` (a dict mapping string -> string).

(This branch also adds optional `onion` URI support, if txtorcon is installed, as that was missing).