### PR TITLE
WebSocket testing support, via Agent-style interface

### DIFF
--- a/autobahn/twisted/test/test_websocket_agent.py
+++ b/autobahn/twisted/test/test_websocket_agent.py
@@ -1,13 +1,37 @@
 
 from twisted.trial import unittest
-from twisted.internet.defer import inlineCallbacks
+from twisted.internet.defer import inlineCallbacks, Deferred
 from autobahn.twisted.testing import create_memory_agent
 from autobahn.twisted.websocket import WebSocketServerProtocol
+from autobahn.twisted.websocket import WebSocketClientProtocol
+
+from twisted.internet import reactor
 
 
 class SpammingWebSocketServerProtocol(WebSocketServerProtocol):
     def onMessage(self, *args, **kw):
         print("SERVER MESSAGE: {} {}".format(args, kw))
+
+
+class LoggingWebSocketServerProtocol(WebSocketServerProtocol):
+
+    messages = []
+    reactor = None
+
+    def onOpen(self):
+        # "break the loop" in synchonous agent behavior that means
+        # we'll "do" all the message-sending before anything gets a
+        # chance to listn ... but XXX THINK do we actually need to do
+        # this "in autobahn" or is this a produce of "all in-memory
+        # transports" which take zero time?
+        def send_messages():
+            for msg in self.messages:
+                print("sending {}".format(msg))
+                self.sendMessage(msg)
+        self.reactor.callLater(0, send_messages)
+
+    def onMessage(self, *args, **kw):
+        print("SERVER GOT MESSAGE: {} {}".format(args, kw))
 
 
 class TestAgent(unittest.TestCase):
@@ -17,8 +41,61 @@ class TestAgent(unittest.TestCase):
 
     @inlineCallbacks
     def test_foo(self):
-        agent = create_memory_agent(SpammingWebSocketServerProtocol)
+        agent = create_memory_agent(SpammingWebSocketServerProtocol, None)
         proto = yield agent.open("ws://localhost:1234/ws", dict())
 
         proto.sendMessage(b"hello")
         agent.flush()
+
+    @inlineCallbacks
+    def test_client_receives_two_messages_subclass(self):
+
+        def make():
+            p = LoggingWebSocketServerProtocol()
+            p.reactor = agent._reactor
+            p.messages = [
+                b"message zero",
+                b"message one",
+            ]
+            return p
+
+        class Mine(WebSocketClientProtocol):
+            messages = []
+
+            def onMessage(self, *args, **kw):
+                self.messages.append((args, kw))
+
+        agent = create_memory_agent(None, make)
+        proto = yield agent.open("ws://localhost:1234/ws", dict(), Mine)
+
+        agent.flush()
+        agent._reactor.advance(1)
+        agent.flush()
+        self.assertEqual(len(proto.messages), 2)
+
+    @inlineCallbacks
+    def test_client_receives_two_messages_listener(self):
+
+        def make():
+            p = LoggingWebSocketServerProtocol()
+            p.reactor = agent._reactor
+            p.messages = [
+                b"message zero",
+                b"message one",
+            ]
+            return p
+
+        agent = create_memory_agent(None, make)
+        proto = yield agent.open("ws://localhost:1234/ws", dict())
+
+        messages = []
+
+        def got_message(*args, **kw):
+            messages.append((args, kw))
+        proto.on("message", got_message)
+
+        agent.flush()
+        agent._reactor.advance(1)  # send the messages
+        agent.flush()
+
+        self.assertEqual(2, len(messages))

--- a/autobahn/twisted/test/test_websocket_agent.py
+++ b/autobahn/twisted/test/test_websocket_agent.py
@@ -1,0 +1,17 @@
+
+from twisted.trial import unittest
+from twisted.internet.defer import inlineCallbacks
+from autobahn.twisted.testing import create_memory_agent
+
+class TestAgent(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    @inlineCallbacks
+    def test_foo(self):
+        agent = create_memory_agent()
+        proto = yield agent.open("ws://localhost:1234/ws", dict())
+
+        proto.sendMessage(b"hello")
+        agent.flush()

--- a/autobahn/twisted/test/test_websocket_agent.py
+++ b/autobahn/twisted/test/test_websocket_agent.py
@@ -48,3 +48,30 @@ class TestAgent(unittest.TestCase):
             proto.transport.loseConnection()
         yield proto.is_closed
         self.assertEqual([b"hello"], messages)
+
+    @inlineCallbacks
+    def test_secure_echo_server(self):
+
+        class EchoServer(WebSocketServerProtocol):
+            def onMessage(self, msg, is_binary):
+                self.sendMessage(msg)
+
+        agent = create_memory_agent(self.reactor, self.pumper, EchoServer)
+        proto = yield agent.open(u"wss://localhost:1234/ws", dict())
+
+        messages = []
+
+        def got(msg, is_binary):
+            messages.append(msg)
+        proto.on("message", got)
+
+        proto.sendMessage(b"hello")
+
+        if True:
+            # clean close
+            proto.sendClose()
+        else:
+            # unclean close
+            proto.transport.loseConnection()
+        yield proto.is_closed
+        self.assertEqual([b"hello"], messages)

--- a/autobahn/twisted/test/test_websocket_agent.py
+++ b/autobahn/twisted/test/test_websocket_agent.py
@@ -30,7 +30,7 @@ class TestAgent(unittest.TestCase):
                 self.sendMessage(msg)
 
         agent = create_memory_agent(self.reactor, self.pumper, EchoServer)
-        proto = yield agent.open("ws://localhost:1234/ws", dict())
+        proto = yield agent.open(u"ws://localhost:1234/ws", dict())
 
         messages = []
 

--- a/autobahn/twisted/test/test_websocket_agent.py
+++ b/autobahn/twisted/test/test_websocket_agent.py
@@ -2,6 +2,13 @@
 from twisted.trial import unittest
 from twisted.internet.defer import inlineCallbacks
 from autobahn.twisted.testing import create_memory_agent
+from autobahn.twisted.websocket import WebSocketServerProtocol
+
+
+class SpammingWebSocketServerProtocol(WebSocketServerProtocol):
+    def onMessage(self, *args, **kw):
+        print("SERVER MESSAGE: {} {}".format(args, kw))
+
 
 class TestAgent(unittest.TestCase):
 
@@ -10,7 +17,7 @@ class TestAgent(unittest.TestCase):
 
     @inlineCallbacks
     def test_foo(self):
-        agent = create_memory_agent()
+        agent = create_memory_agent(SpammingWebSocketServerProtocol)
         proto = yield agent.open("ws://localhost:1234/ws", dict())
 
         proto.sendMessage(b"hello")

--- a/autobahn/twisted/test/test_websocket_agent.py
+++ b/autobahn/twisted/test/test_websocket_agent.py
@@ -8,66 +8,23 @@ from autobahn.twisted.websocket import WebSocketClientProtocol
 from twisted.internet import reactor
 
 
-class SpammingWebSocketServerProtocol(WebSocketServerProtocol):
-    def onMessage(self, *args, **kw):
-        print("SERVER MESSAGE: {} {}".format(args, kw))
-
-
-class LoggingWebSocketServerProtocol(WebSocketServerProtocol):
-
-    messages = []
-    reactor = None
-
-    def onOpen(self):
-        # "break the loop" in synchonous agent behavior that means
-        # we'll "do" all the message-sending before anything gets a
-        # chance to listn ... but XXX THINK do we actually need to do
-        # this "in autobahn" or is this a produce of "all in-memory
-        # transports" which take zero time?
-        def send_messages():
-            for msg in self.messages:
-                print("sending {}".format(msg))
-                self.sendMessage(msg)
-        self.reactor.callLater(0, send_messages)
-
-    def onMessage(self, *args, **kw):
-        print("SERVER GOT MESSAGE: {} {}".format(args, kw))
-
-
 class TestAgent(unittest.TestCase):
 
     def setUp(self):
         self.reactor = MemoryReactorClockResolver()
 
     @inlineCallbacks
-    def _test_foo(self):
-        agent = create_memory_agent(self.reactor, SpammingWebSocketServerProtocol)
-        proto = yield agent.open("ws://localhost:1234/ws", dict())
-
-        proto.sendMessage(b"hello")
-        agent.flush()
-
-    @inlineCallbacks
     def test_echo_server(self):
 
         class EchoServer(WebSocketServerProtocol):
-            def onOpen(self):
-                print("open")
-                print("sent",self.sendMessage(b"hello"))
-
-            def onMesssage(self, msg, isBinary):
-                print("gotmessage {}".format(msg))
-                self.sendMessage(msg, isBinary=is_binary)
-
-            def onClose(*args):
-                print("close {}".format(args))
+            def onMessage(self, msg, is_binary):
+                self.sendMessage(msg)
 
         agent = create_memory_agent(self.reactor, EchoServer)
         proto = yield agent.open("ws://localhost:1234/ws", dict())
 
         messages = []
-        def got(msg, isBinary):
-            print("got", msg)
+        def got(msg, is_binary):
             messages.append(msg)
         proto.on("message", got)
 

--- a/autobahn/twisted/test/test_websocket_agent.py
+++ b/autobahn/twisted/test/test_websocket_agent.py
@@ -76,16 +76,7 @@ class TestAgent(unittest.TestCase):
     @inlineCallbacks
     def test_client_receives_two_messages_listener(self):
 
-        def make():
-            p = LoggingWebSocketServerProtocol()
-            p.reactor = agent._reactor
-            p.messages = [
-                b"message zero",
-                b"message one",
-            ]
-            return p
-
-        agent = create_memory_agent(None, make)
+        agent = create_memory_agent(None, None)
         proto = yield agent.open("ws://localhost:1234/ws", dict())
 
         messages = []
@@ -95,7 +86,8 @@ class TestAgent(unittest.TestCase):
         proto.on("message", got_message)
 
         agent.flush()
-        agent._reactor.advance(1)  # send the messages
-        agent.flush()
 
+        agent.send_server_message_to_client(proto, b"message one")
+        self.assertEqual(1, len(messages))
+        agent.send_server_message_to_client(proto, b"message two")
         self.assertEqual(2, len(messages))

--- a/autobahn/twisted/test/test_websocket_agent.py
+++ b/autobahn/twisted/test/test_websocket_agent.py
@@ -1,11 +1,18 @@
-
 from twisted.trial import unittest
+
+try:
+    from autobahn.twisted.testing import create_memory_agent, MemoryReactorClockResolver, create_pumper
+    HAVE_TESTING = True
+except ImportError:
+    HAVE_TESTING = False
+
 from twisted.internet.defer import inlineCallbacks
-from autobahn.twisted.testing import create_memory_agent, MemoryReactorClockResolver, create_pumper
 from autobahn.twisted.websocket import WebSocketServerProtocol
 
 
 class TestAgent(unittest.TestCase):
+
+    skip = not HAVE_TESTING
 
     def setUp(self):
         self.pumper = create_pumper()

--- a/autobahn/twisted/test/test_websocket_agent.py
+++ b/autobahn/twisted/test/test_websocket_agent.py
@@ -1,11 +1,8 @@
 
 from twisted.trial import unittest
-from twisted.internet.defer import inlineCallbacks, Deferred
+from twisted.internet.defer import inlineCallbacks
 from autobahn.twisted.testing import create_memory_agent, MemoryReactorClockResolver, create_pumper
 from autobahn.twisted.websocket import WebSocketServerProtocol
-from autobahn.twisted.websocket import WebSocketClientProtocol
-
-from twisted.internet import reactor
 
 
 class TestAgent(unittest.TestCase):
@@ -29,6 +26,7 @@ class TestAgent(unittest.TestCase):
         proto = yield agent.open("ws://localhost:1234/ws", dict())
 
         messages = []
+
         def got(msg, is_binary):
             messages.append(msg)
         proto.on("message", got)

--- a/autobahn/twisted/test/test_websocket_agent.py
+++ b/autobahn/twisted/test/test_websocket_agent.py
@@ -1,7 +1,7 @@
 
 from twisted.trial import unittest
 from twisted.internet.defer import inlineCallbacks, Deferred
-from autobahn.twisted.testing import create_memory_agent
+from autobahn.twisted.testing import create_memory_agent, MemoryReactorClockResolver
 from autobahn.twisted.websocket import WebSocketServerProtocol
 from autobahn.twisted.websocket import WebSocketClientProtocol
 
@@ -41,7 +41,8 @@ class TestAgent(unittest.TestCase):
 
     @inlineCallbacks
     def test_foo(self):
-        agent = create_memory_agent(SpammingWebSocketServerProtocol, None)
+        reactor = MemoryReactorClockResolver()
+        agent = create_memory_agent(reactor, SpammingWebSocketServerProtocol, None)
         proto = yield agent.open("ws://localhost:1234/ws", dict())
 
         proto.sendMessage(b"hello")
@@ -65,7 +66,8 @@ class TestAgent(unittest.TestCase):
             def onMessage(self, *args, **kw):
                 self.messages.append((args, kw))
 
-        agent = create_memory_agent(None, make)
+        reactor = MemoryReactorClockResolver()
+        agent = create_memory_agent(reactor, None, make)
         proto = yield agent.open("ws://localhost:1234/ws", dict(), Mine)
 
         agent.flush()
@@ -76,7 +78,8 @@ class TestAgent(unittest.TestCase):
     @inlineCallbacks
     def test_client_receives_two_messages_listener(self):
 
-        agent = create_memory_agent(None, None)
+        reactor = MemoryReactorClockResolver()
+        agent = create_memory_agent(reactor, None, None)
         proto = yield agent.open("ws://localhost:1234/ws", dict())
 
         messages = []

--- a/autobahn/twisted/testing/__init__.py
+++ b/autobahn/twisted/testing/__init__.py
@@ -30,7 +30,7 @@ from __future__ import absolute_import
 # that, it was IResolverSimple only.
 
 try:
-    from twisted.internet.interfaces import  IHostnameResolver
+    from twisted.internet.interfaces import IHostnameResolver
 except ImportError:
     raise ImportError(
         "Twisted 17.1.0 or later required for autobahn.twisted.testing"

--- a/autobahn/twisted/testing/__init__.py
+++ b/autobahn/twisted/testing/__init__.py
@@ -91,10 +91,9 @@ class _TwistedWebMemoryAgent(IWebSocketClientAgent):
     A testing agent.
     """
 
-    def __init__(self, reactor, client_protocol, server_protocol):
+    def __init__(self, reactor, server_protocol):
         self._reactor = reactor
         self._server_protocol = server_protocol
-        self._client_protocol = client_protocol
 
         # our "real" underlying agent under test
         self._agent = _TwistedWebSocketClientAgent(self._reactor)
@@ -176,7 +175,7 @@ class _TwistedWebMemoryAgent(IWebSocketClientAgent):
         self.flush()
 
 
-def create_memory_agent(reactor, client_protocol, server_protocol):
+def create_memory_agent(reactor, server_protocol):
     """
     return a new instance implementing `IWebSocketClientAgent`.
 
@@ -185,8 +184,6 @@ def create_memory_agent(reactor, client_protocol, server_protocol):
     and then exchange data between client and server using purely
     in-memory buffers.
     """
-    if client_protocol is None:
-        client_protocol = WebSocketClientProtocol
     if server_protocol is None:
         server_protocol = WebSocketServerProtocol
-    return _TwistedWebMemoryAgent(reactor, client_protocol, server_protocol)
+    return _TwistedWebMemoryAgent(reactor, server_protocol)

--- a/autobahn/twisted/testing/__init__.py
+++ b/autobahn/twisted/testing/__init__.py
@@ -1,0 +1,58 @@
+###############################################################################
+#
+# The MIT License (MIT)
+#
+# Copyright (c) Crossbar.io Technologies GmbH
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+###############################################################################
+
+from __future__ import absolute_import
+
+from autobahn.websocket.interfaces import IWebSocketClientAgent
+
+
+__all__ = (
+    'create_memory_agent',
+)
+
+
+class _TwistedWebSocketClientAgent(IWebSocketClientAgent):
+    """
+    This agent creates connections using Twisted
+    """
+
+    def __init__(self, reactor):
+        self._reactor = reactor
+
+    def open(self, transport_config, options):
+
+
+
+def create_memory_agent(reactor, resource):
+    """
+    return a new instance implementing `IWebSocketClientAgent`.
+
+    connection attempts will be satisfied by traversing the Upgrade
+    request path starting at `resource` to find a `WebSocketResource`
+    and then exchange data between client and server using purely
+    in-memory buffers.
+    """
+    raise NotImplemented()

--- a/autobahn/twisted/testing/__init__.py
+++ b/autobahn/twisted/testing/__init__.py
@@ -26,7 +26,7 @@
 
 from __future__ import absolute_import
 
-from twisted.internet.defer import inlineCallbacks, Deferred
+from twisted.internet.defer import Deferred
 from twisted.internet.address import IPv4Address
 from twisted.internet._resolver import HostResolution  # FIXME
 from twisted.internet.interfaces import ISSLTransport, IReactorPluggableNameResolver, IHostnameResolver
@@ -39,7 +39,6 @@ from autobahn.websocket.interfaces import IWebSocketClientAgent
 from autobahn.twisted.websocket import _TwistedWebSocketClientAgent
 from autobahn.twisted.websocket import WebSocketServerProtocol
 from autobahn.twisted.websocket import WebSocketServerFactory
-from autobahn.twisted.websocket import WebSocketClientProtocol
 
 
 __all__ = (

--- a/autobahn/twisted/testing/__init__.py
+++ b/autobahn/twisted/testing/__init__.py
@@ -26,7 +26,19 @@
 
 from __future__ import absolute_import
 
+from twisted.internet.defer import inlineCallbacks
+from twisted.internet.address import IPv4Address
+from twisted.internet._resolver import HostResolution  # FIXME
+from twisted.internet.interfaces import ISSLTransport
+from twisted.test.proto_helpers import MemoryReactor, Clock
+from twisted.test import iosim
+
+from zope.interface import directlyProvides, implementer
+
 from autobahn.websocket.interfaces import IWebSocketClientAgent
+from autobahn.twisted.websocket import _TwistedWebSocketClientAgent
+from autobahn.twisted.websocket import WebSocketServerProtocol
+from autobahn.twisted.websocket import WebSocketServerFactory
 
 
 __all__ = (
@@ -39,14 +51,102 @@ class _TwistedWebMemoryAgent(IWebSocketClientAgent):
     A testing agent.
     """
 
-    def __init__(self, reactor):
-        self._reactor = reactor
+    def __init__(self):
+        self._reactor = MemoryReactor()
+
+        # XXX FIXME is there another/better way to do this?
+        # MemoryReactor doesn't have IReactorTime so we graft it on
+        # here:
+        self._clock = Clock()
+        self._reactor.seconds = self._clock.seconds
+        self._reactor.callLater = self._clock.callLater
+
+        # XXX FIXME is there a better way to do this? MemoryReactor
+        # lacks the resolver interface, so we graft it on here (so
+        # HostnameEndpoint works)
+        self._reactor.nameResolver = self
+
+        # our "real" underlying agent under test
+        self._agent = _TwistedWebSocketClientAgent(self._reactor)
+        self._pumps = set()
+
+    def resolveHostName(self, receiver, hostName, portNumber=0):
+        """
+        'really' from IReactorPluggableNameResolver for MemoryReactor
+        FIXME
+        """
+        print("resolve {} {} {}".format(receiver, hostName, portNumber))
+        print(dir(receiver))
+        resolution = HostResolution(hostName)
+        receiver.resolutionBegan(resolution)
+        receiver.addressResolved(
+            IPv4Address('TCP', '127.0.0.1', 31337)
+        )
+        receiver.resolutionComplete()
 
     def open(self, transport_config, options):
-        raise NotImplementedError
+        """
+        This is some proof-of-concept level hacking to see that we can set
+        up an IOPump properly and get a client -> server message
+        through (see autobahn/twisted/test/test_websocket_agent.py
+        """
+        # call our "real" agent
+        client_protocol = self._agent.open(transport_config, options)
+
+        # wss vs ws
+        # host, port, factory, context_factory, timeout, bindAddress = (
+        #     self._memoryReactor.sslClients[-1])
+        host, port, factory, timeout, bindAddress = self._reactor.tcpClients[-1]
+
+        serverAddress = IPv4Address('TCP', '127.0.0.1', port)
+        clientAddress = IPv4Address('TCP', '127.0.0.1', 31337)
+
+        class TestWebSocketServerProtocol(WebSocketServerProtocol):
+
+            def onMessage(self, *args, **kw):
+                print("SERVER MESSAGE: {} {}".format(args, kw))
+
+        serverProtocol = TestWebSocketServerProtocol()
+        serverProtocol.factory = WebSocketServerFactory()
+
+        serverTransport = iosim.FakeTransport(
+            serverProtocol, isServer=True,
+            hostAddress=serverAddress, peerAddress=clientAddress)
+        clientProtocol = factory.buildProtocol(None)
+        clientTransport = iosim.FakeTransport(
+            clientProtocol, isServer=False,
+            hostAddress=clientAddress, peerAddress=serverAddress)
+
+        if "wss":
+            directlyProvides(serverTransport, ISSLTransport)
+            directlyProvides(clientTransport, ISSLTransport)
+
+        pump = iosim.connect(
+            serverProtocol, serverTransport, clientProtocol, clientTransport)
+        self._pumps.add(pump)
+        return client_protocol
+
+    def flush(self):
+        """
+        (XXX copied from treq, MIT license)
+        (XXX not sure if we need this? change docs if so)
+        Flush all data between pending client/server pairs.
+
+        This is only necessary if a :obj:`Resource` under test returns
+        :obj:`NOT_DONE_YET` from its ``render`` method, making a response
+        asynchronous. In that case, after each write from the server,
+        :meth:`pump` must be called so the client can see it.
+        """
+        old_pumps = self._pumps
+        new_pumps = self._pumps = set()
+        for p in old_pumps:
+            p.flush()
+            if p.clientIO.disconnected and p.serverIO.disconnected:
+                continue
+            new_pumps.add(p)
 
 
-def create_memory_agent(reactor, resource):
+def create_memory_agent():
     """
     return a new instance implementing `IWebSocketClientAgent`.
 
@@ -56,4 +156,4 @@ def create_memory_agent(reactor, resource):
     in-memory buffers.
     """
     # XXX FIXME
-    return _TwistedWebMemoryAgent(reactor)
+    return _TwistedWebMemoryAgent()

--- a/autobahn/twisted/testing/__init__.py
+++ b/autobahn/twisted/testing/__init__.py
@@ -26,10 +26,20 @@
 
 from __future__ import absolute_import
 
+# IHostnameResolver et al. were added in Twisted 17.1.0 .. before
+# that, it was IResolverSimple only.
+
+try:
+    from twisted.internet.interfaces import  IHostnameResolver
+except ImportError:
+    raise ImportError(
+        "Twisted 17.1.0 or later required for autobahn.twisted.testing"
+    )
+
 from twisted.internet.defer import Deferred
 from twisted.internet.address import IPv4Address
-from twisted.internet._resolver import HostResolution  # FIXME
-from twisted.internet.interfaces import ISSLTransport, IReactorPluggableNameResolver, IHostnameResolver
+from twisted.internet._resolver import HostResolution  # FIXME?
+from twisted.internet.interfaces import ISSLTransport, IReactorPluggableNameResolver
 from twisted.test.proto_helpers import MemoryReactorClock
 from twisted.test import iosim
 

--- a/autobahn/twisted/testing/__init__.py
+++ b/autobahn/twisted/testing/__init__.py
@@ -34,16 +34,16 @@ __all__ = (
 )
 
 
-class _TwistedWebSocketClientAgent(IWebSocketClientAgent):
+class _TwistedWebMemoryAgent(IWebSocketClientAgent):
     """
-    This agent creates connections using Twisted
+    A testing agent.
     """
 
     def __init__(self, reactor):
         self._reactor = reactor
 
     def open(self, transport_config, options):
-
+        raise NotImplementedError
 
 
 def create_memory_agent(reactor, resource):
@@ -55,4 +55,5 @@ def create_memory_agent(reactor, resource):
     and then exchange data between client and server using purely
     in-memory buffers.
     """
-    raise NotImplemented()
+    # XXX FIXME
+    return _TwistedWebMemoryAgent(reactor)

--- a/autobahn/twisted/testing/__init__.py
+++ b/autobahn/twisted/testing/__init__.py
@@ -51,8 +51,9 @@ class _TwistedWebMemoryAgent(IWebSocketClientAgent):
     A testing agent.
     """
 
-    def __init__(self):
+    def __init__(self, server_protocol=WebSocketServerProtocol):
         self._reactor = MemoryReactorClock()
+        self._server_protocol = server_protocol
 
         # XXX FIXME is there a better way to do this? MemoryReactor
         # lacks the resolver interface, so we graft it on here (so
@@ -68,8 +69,6 @@ class _TwistedWebMemoryAgent(IWebSocketClientAgent):
         'really' from IReactorPluggableNameResolver for MemoryReactor
         FIXME
         """
-        print("resolve {} {} {}".format(receiver, hostName, portNumber))
-        print(dir(receiver))
         resolution = HostResolution(hostName)
         receiver.resolutionBegan(resolution)
         receiver.addressResolved(
@@ -94,12 +93,7 @@ class _TwistedWebMemoryAgent(IWebSocketClientAgent):
         serverAddress = IPv4Address('TCP', '127.0.0.1', port)
         clientAddress = IPv4Address('TCP', '127.0.0.1', 31337)
 
-        class TestWebSocketServerProtocol(WebSocketServerProtocol):
-
-            def onMessage(self, *args, **kw):
-                print("SERVER MESSAGE: {} {}".format(args, kw))
-
-        serverProtocol = TestWebSocketServerProtocol()
+        serverProtocol = self._server_protocol()
         serverProtocol.factory = WebSocketServerFactory()
 
         serverTransport = iosim.FakeTransport(
@@ -139,7 +133,7 @@ class _TwistedWebMemoryAgent(IWebSocketClientAgent):
             new_pumps.add(p)
 
 
-def create_memory_agent():
+def create_memory_agent(protocol):
     """
     return a new instance implementing `IWebSocketClientAgent`.
 
@@ -148,5 +142,4 @@ def create_memory_agent():
     and then exchange data between client and server using purely
     in-memory buffers.
     """
-    # XXX FIXME
-    return _TwistedWebMemoryAgent()
+    return _TwistedWebMemoryAgent(protocol)

--- a/autobahn/twisted/testing/__init__.py
+++ b/autobahn/twisted/testing/__init__.py
@@ -30,7 +30,7 @@ from twisted.internet.defer import inlineCallbacks
 from twisted.internet.address import IPv4Address
 from twisted.internet._resolver import HostResolution  # FIXME
 from twisted.internet.interfaces import ISSLTransport
-from twisted.test.proto_helpers import MemoryReactor, Clock
+from twisted.test.proto_helpers import MemoryReactorClock
 from twisted.test import iosim
 
 from zope.interface import directlyProvides, implementer
@@ -52,14 +52,7 @@ class _TwistedWebMemoryAgent(IWebSocketClientAgent):
     """
 
     def __init__(self):
-        self._reactor = MemoryReactor()
-
-        # XXX FIXME is there another/better way to do this?
-        # MemoryReactor doesn't have IReactorTime so we graft it on
-        # here:
-        self._clock = Clock()
-        self._reactor.seconds = self._clock.seconds
-        self._reactor.callLater = self._clock.callLater
+        self._reactor = MemoryReactorClock()
 
         # XXX FIXME is there a better way to do this? MemoryReactor
         # lacks the resolver interface, so we graft it on here (so

--- a/autobahn/twisted/websocket.py
+++ b/autobahn/twisted/websocket.py
@@ -166,6 +166,7 @@ def _endpoint_from_config(reactor, factory, transport_config, options):
                 # timeout,  option?
                 # attemptDelay,  option?
             )
+    print("made endpoint: {}".format(endpoint))
     return endpoint
 
 
@@ -192,17 +193,18 @@ class _TwistedWebSocketClientAgent(IWebSocketClientAgent):
         # copy it ourselves?
         # ...should we use kwargs for options instead?
         factory = WebSocketClientFactory(
-            self._reactor,
             url=transport_config,
+            reactor=self._reactor,
             # origin=
             # protocols=
             # useragent=
             headers=options['headers'],
             # proxy=
         )
+        factory.protocol = WebSocketClientProtocol
         # XXX might want "contextFactory" for TLS ...? (or e.g. CA etc options?)
 
-        endpoint = _endpoint_from_config(self._reactor, transport_config, options)
+        endpoint = _endpoint_from_config(self._reactor, factory, transport_config, options)
         # XXX what about the part where we wait for handshake?
         return endpoint.connect(factory)
 

--- a/autobahn/twisted/websocket.py
+++ b/autobahn/twisted/websocket.py
@@ -188,8 +188,18 @@ class _TwistedWebSocketClientAgent(IWebSocketClientAgent):
         """
         Open a new connection.
 
-        :returns: a Deferred that fires with a WebSocketClientProtocol
-            that has successfully shaken hands (completed the handshake).
+        :param dict transport_config: valid transport configuration
+
+        :param dict options: additional options for the factory
+
+        :param protocol_class: a callable that returns an instance of
+            the protocol (WebSocketClientProtocol if the default None
+            is passed in)
+
+        :returns: a Deferred that fires with an instance of
+            `protocol_class` (or WebSocketClientProtocol by default)
+            that has successfully shaken hands (completed the
+            handshake).
         """
         check_transport_config(transport_config)
         check_client_options(options)
@@ -197,7 +207,7 @@ class _TwistedWebSocketClientAgent(IWebSocketClientAgent):
         factory = WebSocketClientFactory(
             url=transport_config,
             reactor=self._reactor,
-            **options,
+            **options
         )
         factory.protocol = WebSocketClientProtocol if protocol_class is None else protocol_class
         # XXX might want "contextFactory" for TLS ...? (or e.g. CA etc options?)

--- a/autobahn/twisted/websocket.py
+++ b/autobahn/twisted/websocket.py
@@ -184,7 +184,7 @@ class _TwistedWebSocketClientAgent(IWebSocketClientAgent):
     def __init__(self, reactor):
         self._reactor = reactor
 
-    def open(self, transport_config, options):
+    def open(self, transport_config, options, protocol_class=None):
         """
         Open a new connection.
 
@@ -199,7 +199,7 @@ class _TwistedWebSocketClientAgent(IWebSocketClientAgent):
             reactor=self._reactor,
             **options,
         )
-        factory.protocol = WebSocketClientProtocol
+        factory.protocol = WebSocketClientProtocol if protocol_class is None else protocol_class
         # XXX might want "contextFactory" for TLS ...? (or e.g. CA etc options?)
 
         endpoint = _endpoint_from_config(self._reactor, factory, transport_config, options)

--- a/autobahn/twisted/websocket.py
+++ b/autobahn/twisted/websocket.py
@@ -40,6 +40,7 @@ from twisted.internet.interfaces import ITransport, ISSLTransport
 
 from twisted.internet.error import ConnectionDone, ConnectionAborted, \
     ConnectionLost
+from twisted.internet.defer import Deferred
 
 from autobahn.util import public
 from autobahn.util import _is_tls_error, _maybe_tls_reason
@@ -118,9 +119,15 @@ def check_client_options(options):
         raise ValueError(
             "'options' must be a dict"
         )
-    # XXX probably want to accept "anything that's valid in the
-    # Factory right now" as well...?
-    valid_keys = ["headers"]
+
+    # anything that WebSocketClientFactory accepts (at least)
+    valid_keys = [
+        "origin",
+        "protocols",
+        "useragent",
+        "headers",
+        "proxy",
+    ]
     for actual_k in options.keys():
         if actual_k not in valid_keys:
             raise ValueError(
@@ -188,27 +195,32 @@ class _TwistedWebSocketClientAgent(IWebSocketClientAgent):
         """
         check_transport_config(transport_config)
         check_client_options(options)
-        print("open(): pre-flight checks good")
-        # soooooo, our options could contain 'headers' which is a
-        # mutable dict .. do we "let the user worry" about that, or
-        # copy it ourselves?
-        # ...should we use kwargs for options instead?
+
         factory = WebSocketClientFactory(
             url=transport_config,
             reactor=self._reactor,
-            # origin=
-            # protocols=
-            # useragent=
-            headers=options['headers'],
-            # proxy=
+            **options,
         )
         factory.protocol = WebSocketClientProtocol
         # XXX might want "contextFactory" for TLS ...? (or e.g. CA etc options?)
 
         endpoint = _endpoint_from_config(self._reactor, factory, transport_config, options)
-        # XXX what about the part where we wait for handshake?
-        print("got an endpoint, factory={}".format(factory))
-        return endpoint.connect(factory)
+
+        rtn_d = Deferred()
+        proto_d = endpoint.connect(factory)
+
+        def failed(f):
+            rtn_d.errback(f)
+
+        def got_proto(proto):
+
+            def handshake_completed(arg):
+                rtn_d.callback(proto)
+                return arg
+            proto.is_open.addCallbacks(handshake_completed, failed)
+            return proto
+        proto_d.addCallbacks(got_proto, failed)
+        return rtn_d
 
 
 class WebSocketAdapterProtocol(twisted.internet.protocol.Protocol):

--- a/autobahn/twisted/websocket.py
+++ b/autobahn/twisted/websocket.py
@@ -173,9 +173,7 @@ def _endpoint_from_config(reactor, factory, transport_config, options):
                 # timeout,  option?
                 # attemptDelay,  option?
             )
-    print("made endpoint: {}".format(endpoint))
     return endpoint
-
 
 
 class _TwistedWebSocketClientAgent(IWebSocketClientAgent):
@@ -683,9 +681,7 @@ class WrappingWebSocketClientFactory(WebSocketClientFactory):
             self.setProtocolOptions(perMessageCompressionAccept=accept)
 
     def buildProtocol(self, addr):
-        print("buildprotocol {}".format(addr))
         proto = WrappingWebSocketClientProtocol()
-        print("built {}".format(proto))
         proto.factory = self
         proto._proto = self._factory.buildProtocol(addr)
         proto._proto.transport = proto

--- a/autobahn/twisted/websocket.py
+++ b/autobahn/twisted/websocket.py
@@ -188,6 +188,7 @@ class _TwistedWebSocketClientAgent(IWebSocketClientAgent):
         """
         check_transport_config(transport_config)
         check_client_options(options)
+        print("open(): pre-flight checks good")
         # soooooo, our options could contain 'headers' which is a
         # mutable dict .. do we "let the user worry" about that, or
         # copy it ourselves?
@@ -206,6 +207,7 @@ class _TwistedWebSocketClientAgent(IWebSocketClientAgent):
 
         endpoint = _endpoint_from_config(self._reactor, factory, transport_config, options)
         # XXX what about the part where we wait for handshake?
+        print("got an endpoint, factory={}".format(factory))
         return endpoint.connect(factory)
 
 
@@ -669,7 +671,9 @@ class WrappingWebSocketClientFactory(WebSocketClientFactory):
             self.setProtocolOptions(perMessageCompressionAccept=accept)
 
     def buildProtocol(self, addr):
+        print("buildprotocol {}".format(addr))
         proto = WrappingWebSocketClientProtocol()
+        print("built {}".format(proto))
         proto.factory = self
         proto._proto = self._factory.buildProtocol(addr)
         proto._proto.transport = proto

--- a/autobahn/websocket/interfaces.py
+++ b/autobahn/websocket/interfaces.py
@@ -43,7 +43,7 @@ class IWebSocketClientAgent(object):
     connections.
     """
 
-    def open(self, transport_config, options):
+    def open(self, transport_config, options, protocol_class=None):
         """
         Open a new WebSocket connection.
 

--- a/autobahn/websocket/interfaces.py
+++ b/autobahn/websocket/interfaces.py
@@ -36,6 +36,32 @@ __all__ = ('IWebSocketServerChannelFactory',
            'IWebSocketChannelStreamingApi')
 
 
+@six.add_metaclass(abc.ABCMeta)
+class IWebSocketClientAgent(object):
+    """
+    Instances implementing this interface create WebSocket
+    connections.
+    """
+
+    def open(self, transport_config, options):
+        """
+        Open a new WebSocket connection.
+
+        :returns: a future which fires with a new
+            WebSocketClientProtocol instance which has just completed the
+            handshake, or an error.
+
+        :param transport_config: the endpoint to connect to. A string
+            containing a ws:// or wss:// URI (or a dict containing
+            transport configuration?)
+
+        :param options: any relevant options for this connection
+            attempt. Can include:
+                - headers: a dict() of headers to send
+                - anything currently in Factory / setProtocolOptions?
+        """
+
+
 @public
 @six.add_metaclass(abc.ABCMeta)
 class IWebSocketServerChannelFactory(object):

--- a/autobahn/websocket/protocol.py
+++ b/autobahn/websocket/protocol.py
@@ -3030,7 +3030,7 @@ class WebSocketServerProtocol(WebSocketProtocol):
         if self.trackedTimings:
             self.trackedTimings.track("onOpen")
         self._onOpen()
-        print("signal open")
+
         txaio.resolve(self.is_open, None)
 
         # process rest, if any
@@ -3854,6 +3854,8 @@ class WebSocketClientProtocol(WebSocketProtocol):
                 if self.trackedTimings:
                     self.trackedTimings.track("onOpen")
                 self._onOpen()
+
+            txaio.resolve(self.is_open, None)
 
             # process rest, if any
             #

--- a/autobahn/websocket/protocol.py
+++ b/autobahn/websocket/protocol.py
@@ -550,6 +550,7 @@ class WebSocketProtocol(ObservableMixin):
     def __init__(self):
         #: a Future/Deferred that fires when we hit STATE_CLOSED
         self.is_closed = txaio.create_future()
+        self.is_open = txaio.create_future()
         # XXX should we have open/close here too, or do you HAVE to use is_closed future?
         # XXX what about when_open() and when_closed() as well/instead?
         self.set_valid_events([
@@ -3029,7 +3030,8 @@ class WebSocketServerProtocol(WebSocketProtocol):
         if self.trackedTimings:
             self.trackedTimings.track("onOpen")
         self._onOpen()
-        # XXX could self.fire("open") here if we want
+        print("signal open")
+        txaio.resolve(self.is_open, None)
 
         # process rest, if any
         #

--- a/autobahn/websocket/protocol.py
+++ b/autobahn/websocket/protocol.py
@@ -644,7 +644,7 @@ class WebSocketProtocol(ObservableMixin):
                     fail=f,
                 )
                 # all we can really do here is log; user code error
-            txaio.add_callbacks(None, error)
+            txaio.add_callbacks(f, None, error)
 
         self.message_data = None
 

--- a/autobahn/websocket/protocol.py
+++ b/autobahn/websocket/protocol.py
@@ -51,6 +51,7 @@ from autobahn.websocket.types import ConnectingRequest
 
 from autobahn.util import Stopwatch, newid, wildcards2patterns, encode_truncate
 from autobahn.util import _LazyHexFormatter
+from autobahn.util import ObservableMixin
 from autobahn.websocket.utf8validator import Utf8Validator
 from autobahn.websocket.xormasker import XorMaskerNull, create_xor_masker
 from autobahn.websocket.compress import PERMESSAGE_COMPRESSION_EXTENSION
@@ -358,7 +359,7 @@ class Timings(object):
         return pformat(self._timings)
 
 
-class WebSocketProtocol(object):
+class WebSocketProtocol(ObservableMixin):
     """
     Protocol base class for WebSocket.
 
@@ -549,6 +550,11 @@ class WebSocketProtocol(object):
     def __init__(self):
         #: a Future/Deferred that fires when we hit STATE_CLOSED
         self.is_closed = txaio.create_future()
+        # XXX should we have open/close here too, or do you HAVE to use is_closed future?
+        # XXX what about when_open() and when_closed() as well/instead?
+        self.set_valid_events([
+            "message",  # like onMessage (takes: payload, is_binary=)
+        ])
 
     def onOpen(self):
         """
@@ -627,6 +633,18 @@ class WebSocketProtocol(object):
             if self.trackedTimings:
                 self.trackedTimings.track("onMessage")
             self._onMessage(payload, self.message_is_binary)
+
+            # notify any listeners about this message
+
+            f = self.fire("message", payload, is_binary=self.message_is_binary)
+
+            def error(f):
+                self.log.error(
+                    "Firing signal 'message' failed: {fail}",
+                    fail=f,
+                )
+                # all we can really do here is log; user code error
+            txaio.add_callbacks(None, error)
 
         self.message_data = None
 
@@ -1109,6 +1127,7 @@ class WebSocketProtocol(object):
                 self._onClose(self.wasClean, WebSocketProtocol.CLOSE_STATUS_CODE_ABNORMAL_CLOSE, "connection was closed uncleanly (%s)" % self.wasNotCleanReason)
             else:
                 self._onClose(self.wasClean, self.remoteCloseCode, self.remoteCloseReason)
+            # XXX could self.fire("close", ...) here if we want?
 
     def logRxOctets(self, data):
         """
@@ -3010,6 +3029,7 @@ class WebSocketServerProtocol(WebSocketProtocol):
         if self.trackedTimings:
             self.trackedTimings.track("onOpen")
         self._onOpen()
+        # XXX could self.fire("open") here if we want
 
         # process rest, if any
         #

--- a/examples/twisted/websocket/agent/README.md
+++ b/examples/twisted/websocket/agent/README.md
@@ -1,0 +1,5 @@
+
+Some proof-of-concept usage of the proof-of-concept "Agent"-related
+work for websocket (goal: tests!)
+
+

--- a/examples/twisted/websocket/agent/client.py
+++ b/examples/twisted/websocket/agent/client.py
@@ -16,16 +16,12 @@ async def main(reactor):
     def stuff(*args, **kw):
         print("stuff: {} {}".format(args, kw))
     proto.on('message', stuff)
+    await proto.is_open
 
     proto.sendMessage(b"i am a message\n")
-    await task.deferLater(reactor, 1.0, lambda: None)
-    proto.sendMessage(b"i am a message\n")
-    await task.deferLater(reactor, 1.0, lambda: None)
-    proto.sendMessage(b"i am a message\n")
-    await task.deferLater(reactor, 1.0, lambda: None)
+    await task.deferLater(reactor, 0, lambda: None)
 
-
-    proto.transport.loseConnection()
+    proto.sendClose(code=1000, reason="byebye")
     x = await proto.is_closed
     print("closed {}".format(x))
 

--- a/examples/twisted/websocket/agent/client.py
+++ b/examples/twisted/websocket/agent/client.py
@@ -1,0 +1,35 @@
+
+
+from autobahn.twisted.websocket import create_client_agent
+from twisted.internet import task
+
+
+async def main(reactor):
+    agent = create_client_agent(reactor)
+    options = {
+        "headers": {
+            "x-foo": "bar",
+        }
+    }
+    proto = await agent.open("ws://localhost:9000/ws", options)
+
+    def stuff(*args, **kw):
+        print("stuff: {} {}".format(args, kw))
+    proto.on('message', stuff)
+
+    proto.sendMessage(b"i am a message\n")
+    await task.deferLater(reactor, 1.0, lambda: None)
+    proto.sendMessage(b"i am a message\n")
+    await task.deferLater(reactor, 1.0, lambda: None)
+    proto.sendMessage(b"i am a message\n")
+    await task.deferLater(reactor, 1.0, lambda: None)
+
+
+    proto.transport.loseConnection()
+    x = await proto.is_closed
+    print("closed {}".format(x))
+
+
+if __name__ == "__main__":
+    from twisted.internet.defer import ensureDeferred
+    task.react(lambda r: ensureDeferred(main(r)))

--- a/examples/twisted/websocket/agent/client.py
+++ b/examples/twisted/websocket/agent/client.py
@@ -14,16 +14,17 @@ async def main(reactor):
     proto = await agent.open("ws://localhost:9000/ws", options)
 
     def stuff(*args, **kw):
-        print("stuff: {} {}".format(args, kw))
+        print("on_message: args={} kwargs={}".format(args, kw))
     proto.on('message', stuff)
+
     await proto.is_open
 
     proto.sendMessage(b"i am a message\n")
     await task.deferLater(reactor, 0, lambda: None)
 
     proto.sendClose(code=1000, reason="byebye")
-    x = await proto.is_closed
-    print("closed {}".format(x))
+
+    await proto.is_closed
 
 
 if __name__ == "__main__":

--- a/examples/twisted/websocket/agent/client.py
+++ b/examples/twisted/websocket/agent/client.py
@@ -5,6 +5,10 @@ from twisted.internet import task
 
 
 async def main(reactor):
+    """
+    Using the 'agent' interface to talk to the echo server (run
+    ../echo/server.py for the server, for example)
+    """
     agent = create_client_agent(reactor)
     options = {
         "headers": {
@@ -13,9 +17,9 @@ async def main(reactor):
     }
     proto = await agent.open("ws://localhost:9000/ws", options)
 
-    def stuff(*args, **kw):
+    def got_message(*args, **kw):
         print("on_message: args={} kwargs={}".format(args, kw))
-    proto.on('message', stuff)
+    proto.on('message', got_message)
 
     await proto.is_open
 


### PR DESCRIPTION
This implements #1159 to introduce an "agent-style" interface for creating websocket connections, and a "memory agent" that sets up in-memory connections (instead of real TCP connections). This allows for nicer client/server tests for libraries or applications making use of Autobahn WebSockets.