### PR TITLE
fix packaging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -256,6 +256,7 @@ setup(
         'autobahn.rawsocket.test',
         'autobahn.asyncio',
         'autobahn.twisted',
+        'autobahn.twisted.testing',
         'twisted.plugins',
         'autobahn.nvx',
         'autobahn.nvx.test',


### PR DESCRIPTION
I failed to update the package list in setup.py for https://github.com/crossbario/autobahn-python/pull/1186

This updates it. (aside: does `find_packages` not do the right thing here? that is, can we just use `find_packages` instead?)