### PR TITLE
Prefer the new name of proto_helpers

### DIFF
--- a/autobahn/twisted/test/test_protocol.py
+++ b/autobahn/twisted/test/test_protocol.py
@@ -38,7 +38,10 @@ from twisted.python.failure import Failure
 from twisted.internet.error import ConnectionDone, ConnectionAborted, \
     ConnectionLost
 from twisted.trial import unittest
-from twisted.test.proto_helpers import StringTransport
+try:
+    from twisted.internet.testing import StringTransport
+except ImportError:
+    from twisted.test.proto_helpers import StringTransport
 from autobahn.test import FakeTransport
 
 

--- a/autobahn/twisted/testing/__init__.py
+++ b/autobahn/twisted/testing/__init__.py
@@ -40,7 +40,10 @@ from twisted.internet.defer import Deferred
 from twisted.internet.address import IPv4Address
 from twisted.internet._resolver import HostResolution  # "internal" class, but it's simple
 from twisted.internet.interfaces import ISSLTransport, IReactorPluggableNameResolver
-from twisted.test.proto_helpers import MemoryReactorClock
+try:
+    from twisted.internet.testing import MemoryReactorClock
+except ImportError:
+    from twisted.test.proto_helpers import MemoryReactorClock
 from twisted.test import iosim
 
 from zope.interface import directlyProvides, implementer


### PR DESCRIPTION
Twisted deprecated the `twisted.test.proto_helpers` module and introduced a new `twisted.internet.testing` module with all of the same contents.
