### PR TITLE
cast snappy end message to bytes

### DIFF
--- a/autobahn/websocket/compress_snappy.py
+++ b/autobahn/websocket/compress_snappy.py
@@ -412,7 +412,7 @@ class PerMessageSnappy(PerMessageCompress, PerMessageSnappyMixin):
         return self._compressor.add_chunk(data)
 
     def end_compress_message(self):
-        return ""
+        return b""
 
     def start_decompress_message(self):
         if self._is_server:


### PR DESCRIPTION
The compression caller expects the result of `end_compress_message` to be a byte string, but it was a standard string.

How production-ready is the snappy compression module? Should it just work out of the box?

@oberstet let me know if this is ok.