### PR TITLE
minor fixes

### DIFF
--- a/autobahn/wamp/component.py
+++ b/autobahn/wamp/component.py
@@ -765,7 +765,7 @@ class Component(ObservableMixin):
                             txaio.resolve(done, None)
                         else:
                             f = txaio.create_failure(
-                                ApplicationError(details.reason)
+                                ApplicationError(details.reason, details.message)
                             )
                             txaio.reject(done, f)
                 session.on('leave', on_leave)

--- a/setup.py
+++ b/setup.py
@@ -86,10 +86,8 @@ else:
 
 # non-standard WebSocket compression support (FIXME: consider removing altogether)
 # Ubuntu: sudo apt-get install libsnappy-dev
-# lz4: do we need that anyway?
 extras_require_compress = [
     "python-snappy>=0.5",       # BSD license
-    "lz4>=0.7.0"                # BSD license
 ]
 
 # accelerated JSON and non-JSON WAMP serialization support (namely MessagePack, CBOR and UBJSON)


### PR DESCRIPTION
A couple minor fixes; pass on `message` for on-leave errors and remove dependency on `lz4` (which I don't think is required at all?)