### PR TITLE
raise exception on send when disconnected

### DIFF
--- a/autobahn/exception.py
+++ b/autobahn/exception.py
@@ -37,3 +37,12 @@ class PayloadExceededError(RuntimeError):
     Exception raised when the serialized and framed (eg WebSocket/RawSocket) WAMP payload
     exceeds the transport message size limit.
     """
+
+
+@public
+class Disconnected(RuntimeError):
+    """
+    Exception raised when trying to perform an operation which
+    requires a connection when the WebSocket/RawSocket is not
+    currently connected
+    """

--- a/autobahn/websocket/protocol.py
+++ b/autobahn/websocket/protocol.py
@@ -54,7 +54,7 @@ from autobahn.websocket.utf8validator import Utf8Validator
 from autobahn.websocket.xormasker import XorMaskerNull, create_xor_masker
 from autobahn.websocket.compress import PERMESSAGE_COMPRESSION_EXTENSION
 from autobahn.websocket.util import parse_url
-from autobahn.exception import PayloadExceededError
+from autobahn.exception import PayloadExceededError, Disconnected
 from autobahn.util import _maybe_tls_reason
 
 import txaio
@@ -2187,7 +2187,7 @@ class WebSocketProtocol(ObservableMixin):
         assert type(doNotCompress) == bool, '"doNotCompress" must have type bool, but was "{}"'.format(type(doNotCompress))
 
         if self.state != WebSocketProtocol.STATE_OPEN:
-            return
+            raise Disconnected("Attempt to send on a closed protocol")
 
         if self.trackedTimings:
             self.trackedTimings.track("sendMessage")

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,10 @@
 Changelog
 =========
 
+* change: WebSocket protocol instances now raise
+  `autobahn.exception.Disconnected` when sending on a closed
+  connection
+
 20.1.2
 ------
 


### PR DESCRIPTION
Fixes #1002 .. kind of a change in API, but silently "not sending a message" when the transport is disconnected is surprising.