### PR TITLE
Fix xbr strip for contracts

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,0 @@
-include LICENSE
-include autobahn/nvx/_utf8validator.c
-recursive-include autobahn/wamp/gen/schema *
-recursive-include autobahn/xbr/contracts *

--- a/setup.py
+++ b/setup.py
@@ -164,7 +164,12 @@ packages = [
     'twisted.plugins',
 ]
 
-package_data = {'autobahn.asyncio': ['./test/*']}
+package_data = {
+    '': ['LICENSE'],
+    'autobahn.asyncio': ['./test/*'],
+    'autobahn.nvx': ['_utf8validator.c'],
+    'autobahn.wamp.gen.schema': ['*.bfbs']
+}
 
 entry_points = {
     "console_scripts": [
@@ -178,7 +183,7 @@ if 'AUTOBAHN_STRIP_XBR' in os.environ:
 else:
     extras_require_all += extras_require_xbr
     packages += ['autobahn.xbr', 'autobahn.asyncio.xbr', 'autobahn.twisted.xbr']
-    package_data['xbr'] = ['./xbr/contracts/*.json']
+    package_data['autobahn.xbr'] = ['contracts/*.json']
     entry_points['console_scripts'] += ["xbrnetwork = autobahn.xbr._cli:_main"]
 
 # development dependencies
@@ -275,9 +280,6 @@ setup(
     cffi_modules=cffi_modules,
 
     entry_points=entry_points,
-
-    # this flag will make files from MANIFEST.in go into _source_ distributions only
-    include_package_data=True,
 
     zip_safe=False,
 


### PR DESCRIPTION
Make package data installation conditional for xbr contracts and move `MANIFEST.in` package data installation into setup.py.

Seems I hadn't properly tested `AUTOBAHN_STRIP_XBR` against an autobahn distribution containing the xbr contracts which were actually being installed by `MANIFEST.in` and not `package_data['xbr'] = ['./xbr/contracts/*.json']` as I had assumed which I had copied from [here](https://github.com/crossbario/autobahn-python/blob/v20.3.1/setup.py#L254). Lets just eliminate `MANIFEST.in` and move all package data installation into setup.py.