### PR TITLE
cryptosign authextra allow arbitrary keys

### DIFF
--- a/autobahn/wamp/auth.py
+++ b/autobahn/wamp/auth.py
@@ -157,11 +157,6 @@ class AuthCryptoSign(object):
                 raise ValueError(
                     "Must provide '{}' for cryptosign".format(key)
                 )
-        for key in kw.get('authextra', dict()):
-            if key not in ['pubkey', 'channel_binding']:
-                raise ValueError(
-                    "Unexpected key '{}' in 'authextra'".format(key)
-                )
 
         from autobahn.wamp.cryptosign import SigningKey
         self._privkey = SigningKey.from_key_bytes(


### PR DESCRIPTION
Fixes https://github.com/crossbario/autobahn-python/issues/1412