### PR TITLE
add eth address helpers

### DIFF
--- a/autobahn/xbr/__init__.py
+++ b/autobahn/xbr/__init__.py
@@ -37,7 +37,7 @@ try:
     from autobahn.xbr._abi import XBR_DEBUG_TOKEN_ADDR, XBR_DEBUG_NETWORK_ADDR, XBR_DEBUG_MARKET_ADDR, XBR_DEBUG_CATALOG_ADDR, XBR_DEBUG_CHANNEL_ADDR  # noqa
     from autobahn.xbr._abi import XBR_DEBUG_TOKEN_ADDR_SRC, XBR_DEBUG_NETWORK_ADDR_SRC, XBR_DEBUG_MARKET_ADDR_SRC, XBR_DEBUG_CATALOG_ADDR_SRC, XBR_DEBUG_CHANNEL_ADDR_SRC  # noqa
     from autobahn.xbr._interfaces import IMarketMaker, IProvider, IConsumer, ISeller, IBuyer  # noqa
-    from autobahn.xbr._util import make_w3, pack_uint256, unpack_uint256  # noqa
+    from autobahn.xbr._util import make_w3, pack_uint256, unpack_uint256, with_0x, without_0x  # noqa
 
     from autobahn.xbr._eip712_member_register import sign_eip712_member_register, recover_eip712_member_register  # noqa
     from autobahn.xbr._eip712_member_login import sign_eip712_member_login, recover_eip712_member_login  # noqa
@@ -277,6 +277,8 @@ try:
         'make_w3',
         'pack_uint256',
         'unpack_uint256',
+        'with_0x',
+        'without_0x',
         'generate_seedphrase',
         'check_seedphrase',
         'account_from_seedphrase',

--- a/autobahn/xbr/_util.py
+++ b/autobahn/xbr/_util.py
@@ -148,3 +148,15 @@ def hlcontract(oid):
     if not isinstance(oid, str):
         oid = '{}'.format(oid)
     return hl('<{}>'.format(oid), color='magenta', bold=True)
+
+
+def with_0x(address):
+    if address and not address.startswith('0x'):
+        return '0x{address}'.format(address=address)
+    return address
+
+
+def without_0x(address):
+    if address and address.startswith('0x'):
+        return address[2:]
+    return address


### PR DESCRIPTION
In client libraries there are times when an eth address hex is needed with or without `0x`. ABJS has similar helpers which have proven to be useful.

`binascii.a2b_hex` for example expects the address without `0x`.