### PR TITLE
Limit the number of architectures we build snap on

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,6 +10,16 @@ description: |
 grade: stable
 confinement: strict
 
+architectures:
+  - build-on: amd64
+    run-on: amd64
+
+  - build-on: armhf
+    run-on: armhf
+
+  - build-on: arm64
+    run-on: arm64
+
 apps:
   autobahn:
     command: bin/wamp


### PR DESCRIPTION
* We base our snap on core20 (Ubuntu 20.04), which doesn't really support i386 (https://bugs.launchpad.net/launchpad-buildd/+bug/1890975)
* s390x and ppc64el (waste of energy, really)