### PR TITLE
Allow transport_factory default options modification in AppRunner

### DIFF
--- a/autobahn/asyncio/wamp.py
+++ b/autobahn/asyncio/wamp.py
@@ -160,8 +160,8 @@ class ApplicationRunner(object):
             start a new asyncio loop.
         :type start_loop: bool
 
-        :param kwargs: Key value list of arguments to override default 
-            websocket transport factory options. Allowed parameters are 
+        :param kwargs: Key value list of arguments to override default
+            websocket transport factory options. Allowed parameters are
             defined in :func:`autobanh.websocket.interfaces.IWebSocketClientChannelFactory.setProtocolOptions`
             See the docs: https://autobahn.readthedocs.io/en/latest/websocket/programming.html#websocket-options
 

--- a/autobahn/asyncio/wamp.py
+++ b/autobahn/asyncio/wamp.py
@@ -223,7 +223,7 @@ class ApplicationRunner(object):
                                                  autoPingSize=4,
                                                  perMessageCompressionOffers=offers,
                                                  perMessageCompressionAccept=accept)
-            # update defaults 
+            # update defaults
             transport_factory.setProtocolOptions(**kwargs)
 
         # SSL context for client connection

--- a/autobahn/asyncio/wamp.py
+++ b/autobahn/asyncio/wamp.py
@@ -160,6 +160,11 @@ class ApplicationRunner(object):
             start a new asyncio loop.
         :type start_loop: bool
 
+        :param kwargs: Key value list of arguments to override default 
+            websocket transport factory options. Allowed parameters are 
+            defined in :func:`autobanh.websocket.interfaces.IWebSocketClientChannelFactory.setProtocolOptions`
+            See the docs: https://autobahn.readthedocs.io/en/latest/websocket/programming.html#websocket-options
+
         :returns: None is returned, unless you specify
             `start_loop=False` in which case the coroutine from calling
             `loop.create_connection()` is returned. This will yield the

--- a/autobahn/asyncio/wamp.py
+++ b/autobahn/asyncio/wamp.py
@@ -146,7 +146,7 @@ class ApplicationRunner(object):
         raise NotImplementedError()
 
     @public
-    def run(self, make, start_loop=True, log_level='info'):
+    def run(self, make, start_loop=True, log_level='info', **kwargs):
         """
         Run the application component. Under the hood, this runs the event
         loop (unless `start_loop=False` is passed) so won't return
@@ -223,6 +223,9 @@ class ApplicationRunner(object):
                                                  autoPingSize=4,
                                                  perMessageCompressionOffers=offers,
                                                  perMessageCompressionAccept=accept)
+            # update defaults 
+            transport_factory.setProtocolOptions(**kwargs)
+
         # SSL context for client connection
         if self.ssl is None:
             ssl = isSecure

--- a/autobahn/twisted/wamp.py
+++ b/autobahn/twisted/wamp.py
@@ -210,6 +210,12 @@ class ApplicationRunner(object):
            connect()-ing, we stop the reactor and raise the exception
            back to the caller.
 
+        :param kwargs: Key value list of arguments to override default
+            websocket transport factory options. Allowed parameters are
+            defined in :func:`autobanh.websocket.interfaces.IWebSocketClientChannelFactory.setProtocolOptions`
+            See the docs: https://autobahn.readthedocs.io/en/latest/websocket/programming.html#websocket-options
+
+
         :returns: None is returned, unless you specify
             ``start_reactor=False`` in which case the Deferred that
             connect() returns is returned; this will callback() with

--- a/autobahn/twisted/wamp.py
+++ b/autobahn/twisted/wamp.py
@@ -215,7 +215,6 @@ class ApplicationRunner(object):
             defined in :func:`autobanh.websocket.interfaces.IWebSocketClientChannelFactory.setProtocolOptions`
             See the docs: https://autobahn.readthedocs.io/en/latest/websocket/programming.html#websocket-options
 
-
         :returns: None is returned, unless you specify
             ``start_reactor=False`` in which case the Deferred that
             connect() returns is returned; this will callback() with

--- a/autobahn/twisted/wamp.py
+++ b/autobahn/twisted/wamp.py
@@ -196,7 +196,7 @@ class ApplicationRunner(object):
             return succeed(None)
 
     @public
-    def run(self, make, start_reactor=True, auto_reconnect=False, log_level='info', endpoint=None, reactor=None):
+    def run(self, make, start_reactor=True, auto_reconnect=False, log_level='info', endpoint=None, reactor=None, **kwargs):
         """
         Run the application component.
 
@@ -285,7 +285,8 @@ class ApplicationRunner(object):
                                                  autoPingSize=4,
                                                  perMessageCompressionOffers=offers,
                                                  perMessageCompressionAccept=accept)
-
+            # update defaults 
+            transport_factory.setProtocolOptions(**kwargs)
         # supress pointless log noise
         transport_factory.noisy = False
 

--- a/autobahn/twisted/wamp.py
+++ b/autobahn/twisted/wamp.py
@@ -285,7 +285,7 @@ class ApplicationRunner(object):
                                                  autoPingSize=4,
                                                  perMessageCompressionOffers=offers,
                                                  perMessageCompressionAccept=accept)
-            # update defaults 
+            # update defaults
             transport_factory.setProtocolOptions(**kwargs)
         # supress pointless log noise
         transport_factory.noisy = False


### PR DESCRIPTION
Hi Autobahn,

This a new solution to https://github.com/crossbario/autobahn-python/pull/912 and https://github.com/crossbario/autobahn-python/issues/838:

Adding kwargs to run method allow to modify default transport options:

`runner = ApplicationRunner(url, realm=realm, extra=extra)`
`coro = runner.run(make, start_loop=False, openHandshakeTimeout=10, autoPingSize=5)`

Using a configuration method as suggested  in #912 is not possible because the transport factory is created inside the run method. This commit allows to pass parameters to the transport factory in a seamless way.

Thanks,

Santi
