### PR TITLE
deletes deleted example from README.md

### DIFF
--- a/examples/asyncio/websocket/echo/README.md
+++ b/examples/asyncio/websocket/echo/README.md
@@ -24,10 +24,6 @@ To run the Python client
 
     python client.py ws://127.0.0.1:9000
 
-or (Python 3)
+or
 
     python client_coroutines.py ws://127.0.0.1:9000
-
-or (Python 2)
-
-    python client_coroutines_py2.py ws://127.0.0.1:9000


### PR DESCRIPTION
The example file `examples/ayncio/websocket/echo/client_coroutines_py2.py` has been deleted. I does not make sense anymore to refer to it in the README.