### PR TITLE
Build with nvx by default and don't publish universal wheel.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,13 +29,13 @@ install:
 
 build:
 	-rm -f dist/*
-	# python setup.py sdist bdist_wheel --universal
-	AUTOBAHN_USE_NVX=1 python setup.py sdist bdist_wheel
+	# AUTOBAHN_USE_NVX=0 python setup.py sdist --universal
+	AUTOBAHN_USE_NVX=1 python setup.py sdist
 	ls -la dist
 
 # upload to our internal deployment system
 upload: clean
-	python setup.py sdist bdist_wheel --universal
+	AUTOBAHN_USE_NVX=0 python setup.py sdist --universal
 	aws s3 cp --acl public-read \
 		dist/autobahn-*.whl \
 		s3://fabric-deploy/autobahn/
@@ -69,7 +69,7 @@ clean:
 
 # publish to PyPI
 publish: clean
-	python setup.py sdist bdist_wheel --universal
+	AUTOBAHN_USE_NVX=0 python setup.py sdist --universal
 	twine upload dist/*
 
 clean_docs:

--- a/autobahn/nvx/_utf8validator.py
+++ b/autobahn/nvx/_utf8validator.py
@@ -44,13 +44,18 @@ ffi.cdef("""
     int nvx_utf8vld_get_impl(void* utf8vld);
 """)
 
+optional = True
+if 'AUTOBAHN_USE_NVX' in os.environ and os.environ['AUTOBAHN_USE_NVX'] in ['1', 'true']:
+    optional = False
+
 with open(os.path.join(os.path.dirname(__file__), '_utf8validator.c')) as fd:
     c_source = fd.read()
     ffi.set_source(
         "_nvx_utf8validator",
         c_source,
         libraries=[],
-        extra_compile_args=['-std=c99', '-Wall', '-Wno-strict-prototypes', '-O3', '-march=native']
+        extra_compile_args=['-std=c99', '-Wall', '-Wno-strict-prototypes', '-O3', '-march=native'],
+        optional=optional
     )
 
 

--- a/setup.py
+++ b/setup.py
@@ -110,12 +110,7 @@ extras_require_nvx = [
 
 # cffi based extension modules to build, currently only NVX
 cffi_modules = []
-if 'AUTOBAHN_USE_NVX' in os.environ:
-    # FIXME: building this extension will make the wheel
-    # produced no longer universal (as in "autobahn-18.4.1-py2.py3-none-any.whl").
-    # on the other hand, I don't know how to selectively include this
-    # based on the install flavor the user has chosen (eg pip install autobahn[nvx]
-    # should make the following be included)
+if 'AUTOBAHN_USE_NVX' not in os.environ or os.environ['AUTOBAHN_USE_NVX'] not in ['0', 'false']:
     cffi_modules.append('autobahn/nvx/_utf8validator.py:ffi')
 
 extras_require_xbr = [


### PR DESCRIPTION
Per [docs](https://pythonwheels.com/):
> Warning: If your project has optional C extensions, it is recommended not to publish a universal wheel, because pip will prefer the wheel over a source installation.