### PR TITLE
refactor SigningKey class

### DIFF
--- a/autobahn/wamp/cryptosign.py
+++ b/autobahn/wamp/cryptosign.py
@@ -463,7 +463,6 @@ if HAS_CRYPTOSIGN:
             # the signature
             return txaio.create_future_success(sig.signature)
 
-
     @util.public
     class SigningKey(SigningKeyBase):
         """
@@ -596,7 +595,6 @@ if HAS_CRYPTOSIGN:
                 key = signing.VerifyKey(keydata)
 
             return cls(key, comment)
-
 
     ISigningKey.register(SigningKey)
 

--- a/autobahn/wamp/interfaces.py
+++ b/autobahn/wamp/interfaces.py
@@ -35,7 +35,8 @@ __all__ = (
     'ITransport',
     'ITransportHandler',
     'ISession',
-    'IPayloadCodec'
+    'IPayloadCodec',
+    'ISigningKey'
 )
 
 
@@ -713,6 +714,39 @@ class IAuthenticator(abc.ABC):
         message from the server (e.g. for mutual authentication).
 
         :return: None if the session is successful or an error-message
+        """
+
+@public
+class ISigningKey(abc.ABC):
+
+    @abc.abstractmethod
+    def can_sign(self):
+        """
+        Check if the key can be used to sign.
+
+        :returns: `True`, iff the key can sign.
+        :rtype: bool
+        """
+
+    @abc.abstractmethod
+    def public_key(self):
+        """
+
+        :return:
+        """
+
+    @abc.abstractmethod
+    def sign(self):
+        """
+
+        :return:
+        """
+
+    @abc.abstractmethod
+    def sign_challenge(self):
+        """
+
+        :return:
         """
 
 

--- a/autobahn/wamp/interfaces.py
+++ b/autobahn/wamp/interfaces.py
@@ -25,6 +25,7 @@
 ###############################################################################
 
 import abc
+from typing import Union
 
 from autobahn.util import public
 
@@ -729,24 +730,24 @@ class ISigningKey(abc.ABC):
         """
 
     @abc.abstractmethod
-    def public_key(self):
+    def public_key(self, binary=False) -> Union[str, bytes]:
         """
+        Returns the public key part of a signing key or the (public) verification key.
 
-        :return:
-        """
-
-    @abc.abstractmethod
-    def sign(self):
-        """
-
-        :return:
+        :param binary: If the return type should be binary instead of hex
+        :return: The public key in hex or byte encoding.
         """
 
     @abc.abstractmethod
-    def sign_challenge(self):
+    def sign(self, data: bytes) -> bytes:
         """
+        Sign the given data.
 
-        :return:
+        :param data: The data to be signed.
+        :type data: bytes
+
+        :returns: The signature.
+        :rtype: bytes
         """
 
 

--- a/autobahn/wamp/interfaces.py
+++ b/autobahn/wamp/interfaces.py
@@ -740,7 +740,7 @@ class ISigningKey(abc.ABC):
         """
 
     @abc.abstractmethod
-    def sign(self, data: bytes) -> bytes:
+    def sign(self, data: bytes):
         """
         Sign the given data.
 
@@ -748,7 +748,7 @@ class ISigningKey(abc.ABC):
         :type data: bytes
 
         :returns: The signature.
-        :rtype: bytes
+        :rtype: txaio.Future object that resolves to bytes
         """
 
 

--- a/autobahn/wamp/interfaces.py
+++ b/autobahn/wamp/interfaces.py
@@ -717,6 +717,7 @@ class IAuthenticator(abc.ABC):
         :return: None if the session is successful or an error-message
         """
 
+
 @public
 class ISigningKey(abc.ABC):
 

--- a/tox.ini
+++ b/tox.ini
@@ -120,7 +120,7 @@ commands =
     python -V
     flake8 --version
     flake8 -v --statistics \
-        --ignore=E402,E501,E722,E741,N801,N802,N803,N805,N806,N815 \
+        --ignore=E402,E501,E722,E741,N801,N802,N803,N805,N806,N815,N818 \
         --exclude "autobahn/wamp/message_fbs.py,autobahn/wamp/gen/*" \
         autobahn
 


### PR DESCRIPTION
This is an attempt at fixing https://github.com/crossbario/autobahn-python/issues/1499, however I am putting it out to get feedback if this is the right approach.

This PR adds
* `SigningKeyBase` class, which abstracts out a few methods from the existing `SigningKey` implementation for reusability.
* `ISigningKey` interface, which only defines 4 methods. (missing doc string, will add once this looks "reasonable").