### PR TITLE
Reset transport retry status when connection succeeds

### DIFF
--- a/autobahn/wamp/component.py
+++ b/autobahn/wamp/component.py
@@ -780,6 +780,7 @@ class Component(ObservableMixin):
                 # it completely (i.e. until its Deferred fires) and
                 # then disconnect this session
                 def on_join(session, details):
+                    transport.reset()
                     transport.connect_sucesses += 1
                     self.log.debug("session on_join: {details}", details=details)
                     d = txaio.as_future(self._entry, reactor, session)


### PR DESCRIPTION
`max_retries` is intuitively the number of consecutive failures allowed before aborting.

Use case: The WAMP router should be allowed to restart or connections temporarily lost.