### PR TITLE
Allow optional keys in the transport endpoint configuration

### DIFF
--- a/autobahn/wamp/component.py
+++ b/autobahn/wamp/component.py
@@ -72,7 +72,7 @@ def _validate_endpoint(endpoint, check_native_endpoint=None):
             raise ValueError('invalid type "{}" in endpoint'.format(endpoint['type']))
 
         for k in endpoint.keys():
-            if k not in ['type', 'host', 'port', 'path', 'tls']:
+            if k not in ['type', 'host', 'port', 'path', 'tls', 'timeout', 'version']:
                 raise ValueError(
                     "Invalid key '{}' in endpoint configuration".format(k)
                 )

--- a/autobahn/wamp/component.py
+++ b/autobahn/wamp/component.py
@@ -780,6 +780,7 @@ class Component(ObservableMixin):
                 # it completely (i.e. until its Deferred fires) and
                 # then disconnect this session
                 def on_join(session, details):
+                    transport.reset()
                     transport.connect_sucesses += 1
                     self.log.debug("session on_join: {details}", details=details)
                     d = txaio.as_future(self._entry, reactor, session)


### PR DESCRIPTION
This came from an attempt to give more time to the router to start when both the component and the router services are started together.

I grepped for `endpoint.*get` and found 2 valid keys that cannot be set from the transport config:
* `timeout`
* `version`