### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -262,6 +262,9 @@ setup(
     license='MIT License',
     author='Crossbar.io Technologies GmbH',
     url='http://crossbar.io/autobahn',
+    project_urls={
+        'Source': 'https://github.com/crossbario/autobahn-python',
+    },
     platforms='Any',
     install_requires=[
         'txaio>=21.2.1',        # MIT license (https://github.com/crossbario/txaio)


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help automation tool find the source code for Requests.

Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)