### PR TITLE
component.register docstring param invoke showing "round_robin" instead of  "roundrobin"

### DIFF
--- a/autobahn/wamp/component.py
+++ b/autobahn/wamp/component.py
@@ -391,7 +391,7 @@ class Component(ObservableMixin):
 
             @component.register(
                 "com.example.add",
-                options=RegisterOptions(invoke='round_robin'),
+                options=RegisterOptions(invoke='roundrobin'),
             )
             def add(*args, **kw):
                 print("add({}, {}): event received".format(args, kw))


### PR DESCRIPTION
round_robin -> roundrobin in docstring of register function invoke param