### PR TITLE
Replace unmaintained pyqrcode dependency with qrcode

### DIFF
--- a/autobahn/wamp/auth.py
+++ b/autobahn/wamp/auth.py
@@ -476,17 +476,15 @@ def qrcode_from_totp(secret, label, issuer):
         raise Exception('label must be of type unicode, not {}'.format(type(label)))
 
     try:
-        import pyqrcode
+        import qrcode
+        import qrcode.image.svg
     except ImportError:
-        raise Exception('pyqrcode not installed')
+        raise Exception('qrcode not installed')
 
-    import io
-    buffer = io.BytesIO()
-
-    data = pyqrcode.create('otpauth://totp/{}?secret={}&issuer={}'.format(label, secret, issuer))
-    data.svg(buffer, omithw=True)
-
-    return buffer.getvalue()
+    return qrcode.make(
+        'otpauth://totp/{}?secret={}&issuer={}'.format(label, secret, issuer),
+        box_size=3,
+        image_factory=qrcode.image.svg.SvgImage).to_string()
 
 
 @public

--- a/autobahn/wamp/cryptosign.py
+++ b/autobahn/wamp/cryptosign.py
@@ -295,24 +295,26 @@ def _qrcode_from_signify_ed25519_pubkey(pubkey_file, mode='text'):
     """
     assert(mode in ['text', 'svg'])
 
-    import pyqrcode
+    import qrcode
 
     with open(pubkey_file) as f:
         pubkey = f.read().splitlines()[1]
 
-        qr = pyqrcode.create(pubkey, error='L', mode='binary')
+        qr = qrcode.QRCode(box_size=3,
+                           error_correction=qrcode.ERROR_CORRECT_L)
+        qr.add_data(pubkey)
 
         if mode == 'text':
-            return qr.terminal()
-
-        elif mode == 'svg':
             import io
-            data_buffer = io.BytesIO()
 
-            qr.svg(data_buffer, omithw=True)
+            with io.StringIO() as data_buffer:
+                qr.print_ascii(out=data_buffer, invert=True)
+                return data_buffer.getvalue()
+        elif mode == 'svg':
+            import qrcode.image.svg
 
-            return data_buffer.getvalue()
-
+            image = qr.make_image(image_factory=qrcode.image.svg.SvgImage)
+            return image.to_string()
         else:
             raise Exception('logic error')
 

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ extras_require_encryption = [
     'service_identity>=18.1.0',     # MIT license
     'pynacl>=1.4.0',                # Apache license
     'pytrie>=0.4.0',                # BSD license
-    'pyqrcode>=1.2.1'               # BSD license
+    'qrcode>=7.3.1',                # BSD license
 ]
 
 # Support for WAMP-SCRAM authentication


### PR DESCRIPTION
pyqrcode has not seem any activity since 2015.  Replace it with qrcode
library that is still maintained.  The results are roughly the same;
it seems that there is a tiny difference in SVG scale, and the terminal
version is half the size as qrcode is using more box drawing characters.