### PR TITLE
docs: Fix a few typos

### DIFF
--- a/autobahn/__main__.py
+++ b/autobahn/__main__.py
@@ -54,7 +54,7 @@ txaio.use_twisted()
 
 # XXX other ideas to get 'connection config':
 # - if there .crossbar/ here, load that config and accept a --name or
-#   so to idicate which transport to use
+#   so to indicate which transport to use
 
 # wamp [options] {call,publish,subscribe,register} wamp-uri [args] [kwargs]
 #

--- a/autobahn/websocket/protocol.py
+++ b/autobahn/websocket/protocol.py
@@ -2215,7 +2215,7 @@ class WebSocketProtocol(ObservableMixin):
             self.send_state = WebSocketProtocol.SEND_STATE_INSIDE_MESSAGE
 
         # when =0 : frame was completed exactly
-        # when >0 : frame is still uncomplete and that much amount is still left to complete the frame
+        # when >0 : frame is still incomplete and that much amount is still left to complete the frame
         # when <0 : frame was completed and there was this much unconsumed data in payload argument
         #
         return rest

--- a/examples/twisted/wamp/component/backend.py
+++ b/examples/twisted/wamp/component/backend.py
@@ -56,7 +56,7 @@ component = Component(
 @component.on_join
 def join(session, details):
     print("joined {}: {}".format(session, details))
-    # if you want full tracbacks on the client-side, you enable that
+    # if you want full trackbacks on the client-side, you enable that
     # here:
     # session.traceback_app = True
 


### PR DESCRIPTION
There are small typos in:
- autobahn/__main__.py
- autobahn/websocket/protocol.py
- examples/twisted/wamp/component/backend.py

Fixes:
- Should read `trackbacks` rather than `tracbacks`.
- Should read `indicate` rather than `idicate`.
- Should read `incomplete` rather than `uncomplete`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md