### PR TITLE
Fix building _nvx_utf8validator extension on non-x86 systems

### DIFF
--- a/autobahn/nvx/_utf8validator.c
+++ b/autobahn/nvx/_utf8validator.c
@@ -28,7 +28,9 @@
 #include <stdint.h>
 
 // http://stackoverflow.com/questions/11228855/header-files-for-simd-intrinsics
+#if defined(__SSE2__) || defined(__SSE4_1__)
 #include <x86intrin.h>
+#endif
 
 
 #define UTF8_ACCEPT 0


### PR DESCRIPTION
x86intrin.h does not exist on such systems