### PR TITLE
Support Python 3.11

### DIFF
--- a/autobahn/asyncio/component.py
+++ b/autobahn/asyncio/component.py
@@ -354,8 +354,7 @@ def run(components, start_loop=True, log_level='info'):
     #   import signal
     #   signal.signal(signal.SIGINT, signal.SIG_DFL)
 
-    @asyncio.coroutine
-    def nicely_exit(signal):
+    async def nicely_exit(signal):
         log.info("Shutting down due to {signal}", signal=signal)
 
         try:

--- a/examples/asyncio/wamp/component/backend.py
+++ b/examples/asyncio/wamp/component/backend.py
@@ -40,12 +40,11 @@ def join(session, details):
     "example.foo",
     options=RegisterOptions(details_arg='details'),
 )
-@asyncio.coroutine
-def foo(*args, **kw):
+async def foo(*args, **kw):
     print("foo({}, {})".format(args, kw))
     for x in range(5, 0, -1):
         print("  returning in {}".format(x))
-        yield from asyncio.sleep(1)
+        await asyncio.sleep(1)
     print("returning '42'")
     return 42
 

--- a/examples/asyncio/wamp/component/frontend.py
+++ b/examples/asyncio/wamp/component/frontend.py
@@ -3,27 +3,25 @@
 from autobahn.asyncio.component import Component, run
 from autobahn.wamp.types import RegisterOptions
 from autobahn.wamp.exception import ApplicationError
-import asyncio
 
 
-@asyncio.coroutine
-def main(reactor, session):
+async def main(reactor, session):
     print("Client session={}".format(session))
 
     try:
-        res = yield from session.register(lambda: None, "com.foo.private")
+        res = await session.register(lambda: None, "com.foo.private")
         print("\n\nregistering 'com.foo.private' should have failed\n\n")
     except ApplicationError as e:
         print("registering 'com.foo.private' failed as expected: {}".format(e.error))
 
-    res = yield from session.register(
+    res = await session.register(
         lambda: None, "should.work",
         options=RegisterOptions(match='exact'),
     )
     print("registered 'should.work' with id {}".format(res.id))
 
     try:
-        res = yield from session.register(
+        res = await session.register(
             lambda: None, "prefix.fail.",
             options=RegisterOptions(match='prefix'),
         )
@@ -32,7 +30,7 @@ def main(reactor, session):
         print("prefix-match 'prefix.fail.' failed as expected: {}".format(e.error))
 
     print("calling 'example.foo'")
-    res = yield from session.call("example.foo")
+    res = await session.call("example.foo")
     print("example.foo() = {}".format(res))
 
     print("done")

--- a/examples/asyncio/wamp/overview/frontend.py
+++ b/examples/asyncio/wamp/overview/frontend.py
@@ -1,5 +1,4 @@
 from os import environ
-import asyncio
 from autobahn.asyncio.wamp import ApplicationSession, ApplicationRunner
 
 

--- a/examples/asyncio/wamp/pubsub/options/backend.py
+++ b/examples/asyncio/wamp/pubsub/options/backend.py
@@ -45,8 +45,8 @@ class Component(ApplicationSession):
         counter = 0
         while True:
             publication = await self.publish('com.myapp.topic1',
-                                                  counter,
-                                                  options=PublishOptions(acknowledge=True, exclude_me=False))
+                                             counter,
+                                             options=PublishOptions(acknowledge=True, exclude_me=False))
             print("Event published with publication ID {}".format(publication.id))
             counter += 1
             await asyncio.sleep(1)

--- a/examples/asyncio/wamp/pubsub/options/frontend.py
+++ b/examples/asyncio/wamp/pubsub/options/frontend.py
@@ -46,8 +46,7 @@ class Component(ApplicationSession):
             if self.received > 5:
                 self.leave()
 
-        await self.subscribe(on_event, 'com.myapp.topic1',
-                                  options=SubscribeOptions(details_arg='details'))
+        await self.subscribe(on_event, 'com.myapp.topic1', options=SubscribeOptions(details_arg='details'))
 
     def onDisconnect(self):
         asyncio.get_event_loop().stop()


### PR DESCRIPTION
Python 3.11 removed `asyncio.coroutine` decorator, we were using it. This change enables ABPy to work with python 3.11

also https://github.com/crossbario/autobahn-python/issues/1598