### PR TITLE
Updated web3 and eth-abi to not use beta versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -129,16 +129,14 @@ extras_require_xbr = [
     # ImportError: cannot import name 'getargspec' from 'inspect'
     # https://github.com/ethereum/web3.py/issues/2704#issuecomment-1369041219
     # pip install git+https://github.com/ethereum/web3.py.git
-    # 'web3>=5.31.3',             # MIT license
-    'web3[ipfs] @ git+https://github.com/ethereum/web3.py.git#v6.0.0-beta.9#egg=web3',
+    'web3[ipfs]>=6.0.0',        # MIT license
 
     # the following is needed for EIP712 ("signed typed data"):
     'rlp>=2.0.1',               # MIT license
     'py-eth-sig-utils>=0.4.0',  # MIT license (https://github.com/rmeissner/py-eth-sig-utils)
     'py-ecc>=5.1.0',            # MIT license (https://github.com/ethereum/py_ecc)
 
-    # 'eth-abi>=2.1.1',           # MIT license (https://github.com/ethereum/eth-abi)
-    'eth-abi @ git+https://github.com/ethereum/eth-abi.git@v4.0.0-beta.2#egg=eth-abi',
+    'eth-abi>=4.0.0',           # MIT license (https://github.com/ethereum/eth-abi)
 
     # the following is needed (at least) for BIP32/39 mnemonic processing
     'mnemonic>=0.19',           # MIT license (https://github.com/trezor/python-mnemonic)


### PR DESCRIPTION
These changes are a part of the fix for issue https://github.com/crossbario/crossbar/issues/2069