### PR TITLE
Updates the publish workflow to use the trusted publisher setup

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,12 +43,22 @@ jobs:
     - uses: actions/upload-artifact@v3
       with:
         name: built-packages
+        if-no-files-found: error
         path: |
           ./dist/*.whl
           ./dist/*.tar.gz
 
-    - name: Publish to Pypi
-      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@release/v1
+  publish_release:
+    name: Publish to PyPi
+    runs-on: ubuntu-22.04
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    needs:
+      - build_wheels
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+    steps:
+    - uses: actions/download-artifact@v3
       with:
-        password: ${{ secrets.PYPI_API_TOKEN }}
+        name: built-packages
+    - name: Publish to Pypi
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
I don't know if this is new or I missed it in my original pull request, but this updates the publish job so it will utilize PyPI's [trusted publishing](https://docs.pypi.org/trusted-publishers/) instead of token based auth.  The main benefit seems to be scoped tokens and no more manual publishing.  But it's a minor update to include this and seems to be the preferred way, so here it is.

The action's setup for this can be found here: https://github.com/pypa/gh-action-pypi-publish/tree/release/v1/#trusted-publishing

There is some action to take on PyPI, as described here: https://docs.pypi.org/trusted-publishers/adding-a-publisher/