### PR TITLE
Pass throught custom http headers as transport configuration

### DIFF
--- a/autobahn/wamp/component.py
+++ b/autobahn/wamp/component.py
@@ -121,7 +121,7 @@ def _create_transport(index, transport, check_native_endpoint=None):
         'type', 'url', 'endpoint', 'serializer', 'serializers', 'options',
         'max_retries', 'max_retry_delay', 'initial_retry_delay',
         'retry_delay_growth', 'retry_delay_jitter', 'proxy', 'headers'
-        ]
+    ]
     for k in transport.keys():
         if k not in valid_transport_keys:
             raise ValueError(
@@ -160,7 +160,7 @@ def _create_transport(index, transport, check_native_endpoint=None):
             raise ValueError(
                 'options must be a dict, not {}'.format(type(options))
             )
-    
+
     headers = transport.get("headers")
 
     if kind == 'websocket':

--- a/autobahn/wamp/component.py
+++ b/autobahn/wamp/component.py
@@ -229,7 +229,7 @@ def _create_transport(index, transport, check_native_endpoint=None):
             endpoint_config = transport['endpoint']
         if 'serializers' in transport:
             raise ValueError("'serializers' is only for websocket; use 'serializer'")
-        if headers is None:
+        if headers is not None:
             raise ValueError("'headers' not supported for rawsocket transport")
         # always a list; len == 1 for rawsocket
         if 'serializer' in transport:

--- a/autobahn/wamp/component.py
+++ b/autobahn/wamp/component.py
@@ -120,8 +120,8 @@ def _create_transport(index, transport, check_native_endpoint=None):
     valid_transport_keys = [
         'type', 'url', 'endpoint', 'serializer', 'serializers', 'options',
         'max_retries', 'max_retry_delay', 'initial_retry_delay',
-        'retry_delay_growth', 'retry_delay_jitter', 'proxy',
-    ]
+        'retry_delay_growth', 'retry_delay_jitter', 'proxy', 'headers'
+        ]
     for k in transport.keys():
         if k not in valid_transport_keys:
             raise ValueError(
@@ -160,6 +160,8 @@ def _create_transport(index, transport, check_native_endpoint=None):
             raise ValueError(
                 'options must be a dict, not {}'.format(type(options))
             )
+    
+    headers = transport.get("headers", None)
 
     if kind == 'websocket':
         for key in ['url']:
@@ -252,6 +254,7 @@ def _create_transport(index, transport, check_native_endpoint=None):
         serializers=serializer_config,
         proxy=proxy,
         options=options,
+        headers=headers,
         **kw
     )
 
@@ -268,7 +271,8 @@ class _Transport(object):
                  retry_delay_growth=1.5,
                  retry_delay_jitter=0.1,
                  proxy=None,
-                 options=None):
+                 options=None,
+                 headers=None):
         """
         """
         if options is None:
@@ -279,6 +283,7 @@ class _Transport(object):
         self.url = url
         self.endpoint = endpoint
         self.options = options
+        self.headers = headers
 
         self.serializers = serializers
         if self.type == 'rawsocket' and len(serializers) != 1:

--- a/autobahn/wamp/component.py
+++ b/autobahn/wamp/component.py
@@ -161,7 +161,7 @@ def _create_transport(index, transport, check_native_endpoint=None):
                 'options must be a dict, not {}'.format(type(options))
             )
     
-    headers = transport.get("headers", None)
+    headers = transport.get("headers")
 
     if kind == 'websocket':
         for key in ['url']:
@@ -229,6 +229,8 @@ def _create_transport(index, transport, check_native_endpoint=None):
             endpoint_config = transport['endpoint']
         if 'serializers' in transport:
             raise ValueError("'serializers' is only for websocket; use 'serializer'")
+        if headers is None:
+            raise ValueError("'headers' not supported for rawsocket transport")
         # always a list; len == 1 for rawsocket
         if 'serializer' in transport:
             if not isinstance(transport['serializer'], (str, str)):


### PR DESCRIPTION
This minimalistic PR adds the possibility to specify custom http headers as transport configuration.

Example:

```
component = AutobahnComponent(
  transports={
    "type": "websocket",
    "url": "YOUR URL",
    "headers": {"Authorization": "YOUR CUSTOM AUTHORIZATION"},
  },
    ...
)
```

The patch does not change the internal logic, the configuration is automatically passed and used in the websocket connection factory. I tried to keep the changes minimal (although I was tempted to apply the boy scout rule and do some tidy up work).