### PR TITLE
a couple of packaging fixes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,9 +32,9 @@ jobs:
       run: |
         python3 -m pip install --upgrade pip
 
-    - name: Install build & wheel
+    - name: Install build
       run:
-        pip3 install --upgrade build wheel
+        pip3 install --upgrade build
 
     - name: Build wheel & sdist
       run: |

--- a/Makefile
+++ b/Makefile
@@ -29,13 +29,13 @@ install:
 
 build:
 	-rm -f dist/*
-	# AUTOBAHN_USE_NVX=0 python setup.py sdist --universal
-	AUTOBAHN_USE_NVX=1 python setup.py sdist
+	# AUTOBAHN_USE_NVX=0 python -m build
+	AUTOBAHN_USE_NVX=1 python -m build
 	ls -la dist
 
 # upload to our internal deployment system
 upload: clean
-	AUTOBAHN_USE_NVX=0 python setup.py sdist --universal
+	AUTOBAHN_USE_NVX=0 python -m build
 	aws s3 cp --acl public-read \
 		dist/autobahn-*.whl \
 		s3://fabric-deploy/autobahn/
@@ -71,7 +71,7 @@ rebuild_catalog:
 
 # publish to PyPI
 publish: clean
-	AUTOBAHN_USE_NVX=0 python setup.py sdist
+	AUTOBAHN_USE_NVX=0 python -m build
 	twine upload dist/*
 
 clean_docs:
@@ -171,10 +171,6 @@ test_styleguide:
 # direct test via pytest (only here because of setuptools test integration)
 test_pytest:
 	USE_ASYNCIO=1 python -m pytest -c setup.cfg -rsvx autobahn/
-
-# test via setuptools command
-test_setuptools:
-	python setup.py test
 
 test:
 	tox -e flake8,py37-twtrunk,py37-asyncio

--- a/deploy.sh
+++ b/deploy.sh
@@ -22,7 +22,8 @@ aws --version
 
 # build python source dist and wheels
 echo 'building package ..'
-python setup.py sdist bdist_wheel --universal
+pip install build
+python -m build
 ls -la ./dist
 
 # upload to S3: https://s3.eu-central-1.amazonaws.com/crossbarbuilder/wheels/

--- a/docker/Dockerfile.cpy-slim
+++ b/docker/Dockerfile.cpy-slim
@@ -50,7 +50,7 @@ RUN    apt-get update \
                pkg-config \
                libcairo2-dev \
                libgirepository1.0-dev \
-    && pip install --upgrade --no-cache-dir setuptools pip wheel \
+    && pip install --upgrade --no-cache-dir pip \
     && rm -rf ~/.cache \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker/Dockerfile.pypy-slim
+++ b/docker/Dockerfile.pypy-slim
@@ -55,7 +55,7 @@ RUN    apt-get update \
                pkg-config \
                libcairo2-dev \
                libgirepository1.0-dev \
-    && pip install --upgrade --no-cache-dir setuptools pip wheel \
+    && pip install --upgrade --no-cache-dir pip \
     && rm -rf ~/.cache \
     && rm -rf /var/lib/apt/lists/*
 

--- a/setup.py
+++ b/setup.py
@@ -25,14 +25,12 @@
 ###############################################################################
 
 import os
-import sys
-import shutil
 import platform
+import shutil
+
 from setuptools import setup
-from setuptools.command.test import test as test_command
 
 CPY = platform.python_implementation() == 'CPython'
-PYPY = platform.python_implementation() == 'PyPy'
 
 # read version string
 with open('autobahn/_version.py') as f:
@@ -51,13 +49,10 @@ extras_require_twisted = [
 ]
 
 # C-based WebSocket acceleration (only use on CPython, not PyPy!)
-if CPY and sys.platform != 'win32':
-    # wsaccel does not provide wheels: https://github.com/methane/wsaccel/issues/12
-    extras_require_accelerate = [
-        # "wsaccel>=0.6.3"            # Apache 2.0
-    ]
-else:
-    extras_require_accelerate = []
+# wsaccel does not provide wheels: https://github.com/methane/wsaccel/issues/12
+extras_require_accelerate = [
+    # "wsaccel>=0.6.3 ; platform_python_implementation == 'CPython' and sys_platform != 'win32'"  # Apache 2.0
+]
 
 # non-standard WebSocket compression support (FIXME: consider removing altogether)
 # Ubuntu: sudo apt-get install libsnappy-dev
@@ -67,16 +62,13 @@ extras_require_compress = [
 
 # accelerated JSON and non-JSON WAMP serialization support (namely MessagePack, CBOR and UBJSON)
 extras_require_serialization = []
-if CPY:
-    extras_require_serialization.extend([
-        'msgpack>=1.0.2',           # Apache 2.0 license
-        'ujson>=4.0.2',             # BSD license
-    ])
-else:
+extras_require_serialization.extend([
+    'msgpack>=1.0.2 ; platform_python_implementation == "CPython"',           # Apache 2.0 license
+    'ujson>=4.0.2 ; platform_python_implementation == "CPython"',             # BSD license
+    'u-msgpack-python>=2.1 ; platform_python_implementation != "CPython"',    # MIT license
+])
+if not CPY:
     os.environ['PYUBJSON_NO_EXTENSION'] = '1'  # enforce use of pure Python py-ubjson (no Cython)
-    extras_require_serialization.extend([
-        'u-msgpack-python>=2.1',    # MIT license
-    ])
 
 extras_require_serialization.extend([
     'cbor2>=5.2.0',             # MIT license
@@ -227,33 +219,6 @@ with open('requirements-dev.txt') as f:
         if not line.startswith('#'):
             extras_require_dev.append(line)
 
-# for testing by users with "python setup.py test" (not Tox, which we use)
-test_requirements = [
-    "pytest>=2.8.6,<3.3.0",             # MIT license
-]
-
-
-class PyTest(test_command):
-    """
-    pytest integration for setuptools.
-
-    see:
-      - http://pytest.org/latest/goodpractises.html#integration-with-setuptools-test-commands
-      - https://github.com/pyca/cryptography/pull/678/files
-    """
-
-    def finalize_options(self):
-        test_command.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
-
-    def run_tests(self):
-        # Import here because in module scope the eggs are not loaded.
-        import pytest
-        errno = pytest.main(self.test_args)
-        sys.exit(errno)
-
-
 setup(
     name='autobahn',
     version=__version__,  # noqa
@@ -285,10 +250,6 @@ setup(
         'dev': extras_require_dev,
         'xbr': extras_require_xbr,
         'ui': extras_require_ui,
-    },
-    tests_require=test_requirements,
-    cmdclass={
-        'test': PyTest
     },
     packages=packages,
     package_data=package_data,


### PR DESCRIPTION
- use pep 508 markers to statically express dependencies
- remove deprecated use of setup.py as a command line tool

I noticed in passing that this claim in setup.py
```
 # wsaccel does not provide wheels: https://github.com/methane/wsaccel/issues/12
```
has not been true for some time, but left it alone