### PR TITLE
This branch pins setuptools to 70.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -235,7 +235,7 @@ setup(
         'txaio>=21.2.1',        # MIT license (https://github.com/crossbario/txaio)
         'cryptography>=3.4.6',  # BSD *or* Apache license (https://github.com/pyca/cryptography)
         'hyperlink>=21.0.0',    # MIT license (https://github.com/python-hyper/hyperlink)
-        'setuptools',           # MIT license (https://github.com/pypa/setuptools)
+        'setuptools==70.0.0',   # MIT license (https://github.com/pypa/setuptools)
     ],
     extras_require={
         'all': extras_require_all,


### PR DESCRIPTION
which is a wellknown stable version of setuptools
and has been done to avoid issues such as the one
in the link given below

https://github.com/pypa/setuptools/issues/4519