### PR TITLE
Stop using twisted.internet.defer.returnValue

### DIFF
--- a/autobahn/twisted/cryptosign.py
+++ b/autobahn/twisted/cryptosign.py
@@ -27,7 +27,7 @@
 
 from autobahn.wamp.cryptosign import HAS_CRYPTOSIGN, CryptosignKey
 
-from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.internet.defer import inlineCallbacks
 
 __all__ = [
     'HAS_CRYPTOSIGN_SSHAGENT'
@@ -118,7 +118,7 @@ if HAS_CRYPTOSIGN_SSHAGENT:
 
                 if key_data:
                     key = signing.VerifyKey(key_data)
-                    returnValue(cls(key, key_comment, reactor))
+                    return cls(key, key_comment, reactor)
                 else:
                     raise Exception("Ed25519 key not held in ssh-agent")
 
@@ -147,6 +147,6 @@ if HAS_CRYPTOSIGN_SSHAGENT:
 
                 agent.transport.loseConnection()
 
-                returnValue(signature)
+                return signature
 
             return d.addCallback(on_connect)

--- a/autobahn/twisted/wamp.py
+++ b/autobahn/twisted/wamp.py
@@ -596,19 +596,7 @@ class Application(object):
               return a + b
 
         If the function `yields` (is a co-routine), the `@inlineCallbacks` decorator
-        will be applied automatically to it. In that case, if you wish to return something,
-        you should use `returnValue`:
-
-        :Example:
-
-        .. code-block:: python
-
-           from twisted.internet.defer import returnValue
-
-           @app.register('com.myapp.add2')
-           def add2(a, b):
-              res = yield stuff(a, b)
-              returnValue(res)
+        will be applied automatically to it.
 
         :param uri: The URI of the procedure to register under.
         :type uri: unicode

--- a/autobahn/wamp/test/test_wamp_protocol.py
+++ b/autobahn/wamp/test/test_wamp_protocol.py
@@ -29,7 +29,7 @@ import unittest.mock as mock
 
 if os.environ.get('USE_TWISTED', False):
 
-    from twisted.internet.defer import inlineCallbacks, Deferred, returnValue
+    from twisted.internet.defer import inlineCallbacks, Deferred
     from twisted.internet.defer import succeed, fail, DeferredList
     from twisted.trial import unittest
     import twisted
@@ -814,7 +814,7 @@ if os.environ.get('USE_TWISTED', False):
                 for i in range(10):
                     details.progress(i)
                     yield succeed(i)
-                returnValue(42)
+                return 42
 
             progressive = list(map(lambda _: Deferred(), range(10)))
 
@@ -850,7 +850,7 @@ if os.environ.get('USE_TWISTED', False):
                 self.assertEqual('arg', arg)
                 details.progress('life', something='nothing')
                 yield succeed('meaning of')
-                returnValue(42)
+                return 42
 
             got_progress = Deferred()
             progress_error = NameError('foo')
@@ -899,7 +899,7 @@ if os.environ.get('USE_TWISTED', False):
                 self.assertTrue(details.progress is not None)
                 details.progress()
                 yield succeed(True)
-                returnValue(42)
+                return 42
 
             got_progress = Deferred()
 
@@ -931,7 +931,7 @@ if os.environ.get('USE_TWISTED', False):
                 self.assertTrue(details.progress is not None)
                 details.progress(key='word')
                 yield succeed(True)
-                returnValue(42)
+                return 42
 
             got_progress = Deferred()
 

--- a/docs/asynchronous-programming.rst
+++ b/docs/asynchronous-programming.rst
@@ -246,13 +246,13 @@ Now, when converted to ``inlineCallbacks``, the code becomes:
    :emphasize-lines: 5,7,8
 
    from twisted.internet import reactor
-   from twisted.internet.defer import inlineCallbacks, returnValue
+   from twisted.internet.defer import inlineCallbacks
    from autobahn.twisted.util import sleep
 
    @inlineCallbacks
    def slow_square(x):
       yield sleep(1)
-      returnValue(x * x)
+      return x * x
 
    @inlineCallbacks
    def test():
@@ -268,11 +268,6 @@ Have a look at the highlighted lines - here is what we do:
 
 1. Decorating our squaring function with ``inlineCallbacks`` (line 5). Doing so marks the function as a coroutine which allows us to use this sequential looking coding style.
 2. Inside the function, we simulate the slow execution by sleeping for a second (line 7). However, we are sleeping in a non-blocking way (``autobahn.twisted.util.sleep``). The ``yield`` will put the coroutine aside until the sleep returns.
-3. To return values from Twisted coroutines, we need to use ``returnValue`` (line 8).
-
-.. note::
-
-   The reason ``returnValue`` is necessary goes deep into implementation details of Twisted and Python. In short: co-routines in Python 2 with Twisted are simulated using exceptions. Only Python 3.3+ has gotten native support for co-routines using the new yield from statement, Python 3.5+ use await statement and it is the new recommended method.
 
 In above, we are using a little helper ``autobahn.twisted.util.sleep`` for sleeping "inline". The helper is really trivial:
 
@@ -374,8 +369,7 @@ Now, when converted to ``asyncio.coroutine``, the code becomes:
 The main differences (on surface) are:
 
 1. The declaration of the function with ``async`` keyword (line 3) in asyncio versus the decorator ``@defer.inlineCallbacks`` with Twisted
-2. The use of ``defer.returnValue`` in Twisted for returning values whereas in asyncio, you can use plain returns (line 6)
-3. The use of ``await`` in asyncio, versus ``yield`` in Twisted (line 5)
-4. The auxiliary code to get the event loop started and stopped
+2. The use of ``await`` in asyncio, versus ``yield`` in Twisted (line 5)
+3. The auxiliary code to get the event loop started and stopped
 
 Most of the examples that follow will show code for both Twisted and asyncio, unless the conversion is trivial.

--- a/docs/listings/programming.py
+++ b/docs/listings/programming.py
@@ -1,7 +1,7 @@
 from autobahn.twisted.component import Component, run
 from autobahn.twisted.util import sleep
 from autobahn.wamp.types import RegisterOptions
-from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.internet.defer import inlineCallbacks
 
 # to see how this works on the Crossbar.io side, see the example
 # router configuration in:
@@ -61,7 +61,7 @@ def foo(*args, **kw):
         print("  returning in {}".format(x))
         yield sleep(1)
     print("returning '42'")
-    returnValue(42)
+    return 42
 
 
 if __name__ == "__main__":

--- a/docs/listings/tx_complete.py
+++ b/docs/listings/tx_complete.py
@@ -1,7 +1,7 @@
 from autobahn.twisted.component import Component, run
 from autobahn.twisted.util import sleep
 from autobahn.wamp.types import RegisterOptions
-from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.internet.defer import inlineCallbacks
 
 # to see how this works on the Crossbar.io side, see the example
 # router configuration in:
@@ -61,7 +61,7 @@ def foo(*args, **kw):
         print("  returning in {}".format(x))
         yield sleep(1)
     print("returning '42'")
-    returnValue(42)
+    return 42
 
 
 if __name__ == "__main__":

--- a/docs/work/apps.rst
+++ b/docs/work/apps.rst
@@ -80,8 +80,7 @@ a more convincing demo.
 If you use "yield" inside any of the callbacks, `@inlineCallbacks` will
 be applied automatically. It means every yielded line will be be added in
 a Deferred so they execute sequentially, in regards to the other yielded
-lines in the same function. In that case, you should not `return`, but use
-`returnValue`.
+lines in the same function.
 
 :Example:
 
@@ -89,7 +88,6 @@ lines in the same function. In that case, you should not `return`, but use
 
    from autobahn.twisted.wamp import Application
 
-   from twisted.internet.defer import returnValue
    from twisted.web.client import Agent
 
    app = Application()
@@ -106,9 +104,7 @@ lines in the same function. In that case, you should not `return`, but use
       # Asynchronous GET request on the url
       d = yield agent.request('GET', url)
 
-      # Using returnValue and not return because the whole
-      # procedure is a coroutine since we used yield.
-      returnValue(d.code)
+      return d.code
 
    @app.signal('onjoin')
    def entry_point():

--- a/examples/run-all-examples.py
+++ b/examples/run-all-examples.py
@@ -22,7 +22,7 @@ import colorama
 from colorama import Fore
 
 from twisted.internet.protocol import ProcessProtocol
-from twisted.internet.defer import inlineCallbacks, Deferred, returnValue
+from twisted.internet.defer import inlineCallbacks, Deferred
 from twisted.internet.error import ProcessExitedAlready
 from twisted.internet import reactor
 from twisted.internet.task import react
@@ -108,7 +108,7 @@ def start_crossbar():
     else:
         DELAY = 2.
     yield sleep(DELAY)
-    returnValue(protocol)
+    return protocol
 
 
 @inlineCallbacks
@@ -124,7 +124,7 @@ def start_example(py_fname, color, prefix='', exe=sys.executable):
     reactor.spawnProcess(protocol, exe, args, path='.', env=env)
 
     yield launched
-    returnValue(protocol)
+    return protocol
 
 
 def print_banner(title):
@@ -232,8 +232,8 @@ def main(reactor):
         print()
         print("Success!")
         print("  ...all the examples neither crashed nor burned...")
-        returnValue(0)
-    returnValue(5)
+        return 0
+    return 5
 
 
 if __name__ == '__main__':

--- a/examples/twisted/wamp/app/crochet/example2/server.py
+++ b/examples/twisted/wamp/app/crochet/example2/server.py
@@ -30,7 +30,6 @@ from crochet import setup, run_in_reactor, wait_for
 # this MUST be called _before_ any Autobahn or Twisted imports!
 setup()
 
-from twisted.internet.defer import returnValue  # noqa
 from autobahn.twisted.util import sleep  # noqa
 from autobahn.twisted.wamp import Application  # noqa
 
@@ -50,7 +49,7 @@ def square(x):
 def slowsquare(x):
     print("slowsquare() called with {}".format(x))
     yield sleep(2)
-    returnValue(x * x)
+    return x * x
 
 
 # the following are synchronous wrappers around the asynchronous WAMP code

--- a/examples/twisted/wamp/app/hello/hello.py
+++ b/examples/twisted/wamp/app/hello/hello.py
@@ -25,7 +25,6 @@
 ###############################################################################
 
 from os import environ
-from twisted.internet.defer import returnValue
 from autobahn.twisted.wamp import Application
 
 
@@ -42,7 +41,7 @@ def add2(a, b):
 def hello():
     print("hello() called")
     res = yield app.session.call('com.example.add2', 2, 3)
-    returnValue("Hello {}".format(res))
+    return "Hello {}".format(res)
 
 
 @app.signal('onjoined')

--- a/examples/twisted/wamp/app/klein/example1/server_web.py
+++ b/examples/twisted/wamp/app/klein/example1/server_web.py
@@ -24,7 +24,7 @@
 #
 ###############################################################################
 
-from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.internet.defer import inlineCallbacks
 from klein import Klein
 from autobahn.twisted.wamp import Application
 
@@ -37,7 +37,7 @@ wampapp = Application()
 def square_submit(request):
     x = int(request.args.get('x', [0])[0])
     res = yield wampapp.session.call('com.example.square', x)
-    returnValue("{} squared is {}".format(x, res))
+    return "{} squared is {}".format(x, res)
 
 
 if __name__ == "__main__":

--- a/examples/twisted/wamp/app/klein/example2/server.py
+++ b/examples/twisted/wamp/app/klein/example2/server.py
@@ -27,7 +27,7 @@
 import jinja2
 from klein import Klein
 
-from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.internet.defer import inlineCallbacks
 from autobahn.twisted.wamp import Application
 
 
@@ -62,8 +62,7 @@ def home(request):
 def square(request, x):
     result = yield wampapp.session.call('com.example.square', x)
     page = webapp.templates.get_template('result.html')
-    content = page.render(x=x, result=result)
-    returnValue(content)
+    return page.render(x=x, result=result)
 
 
 @webapp.route('/square/submit', methods=['POST'])

--- a/examples/twisted/wamp/component/backend.py
+++ b/examples/twisted/wamp/component/backend.py
@@ -3,7 +3,7 @@
 from autobahn.twisted.component import Component, run
 from autobahn.twisted.util import sleep
 from autobahn.wamp.types import RegisterOptions
-from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.internet.defer import inlineCallbacks
 from twisted.internet._sslverify import OpenSSLCertificateAuthorities
 from twisted.internet.ssl import CertificateOptions
 from twisted.internet.ssl import optionsForClientTLS, Certificate
@@ -73,7 +73,7 @@ def foo(*args, **kw):
         print("  returning in {}".format(x))
         yield sleep(1)
     print("returning '42'")
-    returnValue(42)
+    return 42
 
 
 if __name__ == "__main__":

--- a/examples/twisted/wamp/rpc/progress/backend.py
+++ b/examples/twisted/wamp/rpc/progress/backend.py
@@ -25,7 +25,7 @@
 ###############################################################################
 
 from os import environ
-from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.internet.defer import inlineCallbacks
 
 from autobahn.wamp.types import RegisterOptions
 from autobahn.twisted.util import sleep
@@ -51,7 +51,7 @@ class Component(ApplicationSession):
             else:
                 # process like a normal call (not producing progressive results)
                 yield sleep(1 * n)
-            returnValue(n)
+            return n
 
         yield self.register(longop, 'com.myapp.longop', RegisterOptions(details_arg='details'))
 

--- a/examples/twisted/wamp/rpc/slowsquare/backend.py
+++ b/examples/twisted/wamp/rpc/slowsquare/backend.py
@@ -25,8 +25,7 @@
 ###############################################################################
 
 from os import environ
-from twisted.internet.defer import inlineCallbacks, \
-    returnValue
+from twisted.internet.defer import inlineCallbacks
 
 from autobahn.twisted.wamp import ApplicationSession, ApplicationRunner
 from autobahn.twisted.util import sleep
@@ -49,7 +48,7 @@ class Component(ApplicationSession):
         @inlineCallbacks
         def slowsquare(x, delay=1):
             yield sleep(delay)
-            returnValue(x * x)
+            return x * x
 
         yield self.register(slowsquare, 'com.math.slowsquare')
 

--- a/examples/twisted/websocket/slowsquare/server.py
+++ b/examples/twisted/websocket/slowsquare/server.py
@@ -29,8 +29,7 @@ from autobahn.twisted.websocket import WebSocketServerProtocol, \
 
 import json
 from twisted.internet.defer import Deferred, \
-    inlineCallbacks, \
-    returnValue
+    inlineCallbacks
 
 
 def sleep(delay):
@@ -47,7 +46,7 @@ class SlowSquareServerProtocol(WebSocketServerProtocol):
             raise Exception("number too large")
         else:
             yield sleep(1)
-            returnValue(x * x)
+            return x * x
 
     @inlineCallbacks
     def onMessage(self, payload, isBinary):


### PR DESCRIPTION
`defer.returnValue` was only needed in Python 2; in Python 3, a simple `return` is fine.

`twisted.internet.defer.returnValue` is deprecated as of Twisted 24.7.0.