### PR TITLE
attempt to fix CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
 
   build_wheels:
     name: Build & Upload
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
       # WEB3_INFURA_PROJECT_ID: ${{ secrets.WEB3_INFURA_PROJECT_ID }}
       # WEB3_INFURA_API_SECRET: ${{ secrets.WEB3_INFURA_API_SECRET }}
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
 
@@ -52,8 +52,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04]
-        # os: [ubuntu-22.04, macos-latest, windows-latest]
+        os: [ubuntu-24.04]
+        # os: [ubuntu-24.04, macos-latest, windows-latest]
 
         # python 3.11 fails with "src/twisted/test/raiser.c:198:12: fatal error: longintrepr.h: No such file or directory"
         # twisted doesn't yet support 3.11 formally: https://github.com/twisted/twisted/blob/trunk/pyproject.toml#L24
@@ -113,7 +113,7 @@ jobs:
         tox -c tox.ini -e ${{ matrix.framework }}
 
   docs:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,9 +21,13 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Install OS package dependencies
-      run: |
-        sudo apt update
-        sudo apt install libenchant-2-dev libbz2-dev libsnappy-dev libunwind-dev libgirepository-2.0-dev libcairo2-dev
+      run: sudo apt-get update && \
+              sudo apt install libenchant-2-dev \
+                               libbz2-dev \
+                               libsnappy-dev \
+                               libunwind-dev \
+                               libgirepository-2.0-dev \
+                               libcairo2-dev
 
     - name: Set up Python 3.11
       uses: actions/setup-python@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Install OS package dependencies
       run: |
         sudo apt update
-        sudo apt install libenchant-2-dev libbz2-dev libsnappy-dev libunwind-dev libgirepository1.0-dev
+        sudo apt install libenchant-2-dev libbz2-dev libsnappy-dev libunwind-dev libgirepository-2.0-dev libcairo2-dev
 
     - name: Set up Python 3.11
       uses: actions/setup-python@v3


### PR DESCRIPTION
CI on main is [currently failing](https://github.com/crossbario/autobahn-python/actions/runs/14976696211/job/42070723486) with this error:

```
    ../meson.build:31:9: ERROR: Dependency 'girepository-2.0' is required but not found.
```
Probably just a missing dependancies that was previously present by default on ubuntu images. Let's try to fix it in this PR. I think we are experiencing the same problem than https://github.com/beeware/toga/issues/3143 (TLDR: pygobject packaging changed)