### PR TITLE
attempt to fix CI - continued

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
 
   build_wheels:
     name: Build & Upload
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
       # WEB3_INFURA_PROJECT_ID: ${{ secrets.WEB3_INFURA_PROJECT_ID }}
       # WEB3_INFURA_API_SECRET: ${{ secrets.WEB3_INFURA_API_SECRET }}
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
 
@@ -52,8 +52,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04]
-        # os: [ubuntu-22.04, macos-latest, windows-latest]
+        os: [ubuntu-24.04]
+        # os: [ubuntu-24.04, macos-latest, windows-latest]
 
         # python 3.11 fails with "src/twisted/test/raiser.c:198:12: fatal error: longintrepr.h: No such file or directory"
         # twisted doesn't yet support 3.11 formally: https://github.com/twisted/twisted/blob/trunk/pyproject.toml#L24
@@ -113,7 +113,7 @@ jobs:
         tox -c tox.ini -e ${{ matrix.framework }}
 
   docs:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
 
         # python 3.11 fails with "src/twisted/test/raiser.c:198:12: fatal error: longintrepr.h: No such file or directory"
         # twisted doesn't yet support 3.11 formally: https://github.com/twisted/twisted/blob/trunk/pyproject.toml#L24
-        python-version: ['3.9', '3.11', 'pypy-3.9']
+        python-version: ['3.9', '3.11', 'pypy-3.10']
         framework: ['asyncio', 'tw2403', 'twtrunk']
 
     # https://github.blog/changelog/2020-04-15-github-actions-new-workflow-features/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Install OS package dependencies
       run: |
         sudo apt update
-        sudo apt install libenchant-2-dev libbz2-dev libsnappy-dev libunwind-dev libgirepository1.0-dev
+        sudo apt install libenchant-2-dev libbz2-dev libsnappy-dev libunwind-dev libgirepository-2.0-dev libcairo2-dev
 
     - name: Set up Python 3.11
       uses: actions/setup-python@v3
@@ -79,7 +79,7 @@ jobs:
         sudo apt update
         sudo apt install build-essential libssl-dev libffi-dev libunwind-dev \
           libreadline-dev zlib1g-dev libbz2-dev libsqlite3-dev libncurses5-dev \
-          libsnappy-dev libgirepository1.0-dev
+          libsnappy-dev libgirepository-2.0-dev libcairo2-dev
 
     # Use this Python
     # https://github.com/actions/setup-python/blob/main/README.md
@@ -120,7 +120,7 @@ jobs:
     - name: Install OS package dependencies
       run: |
         sudo apt update
-        sudo apt install libenchant-2-dev libbz2-dev libsnappy-dev libunwind-dev libgirepository1.0-dev
+        sudo apt install libenchant-2-dev libbz2-dev libsnappy-dev libunwind-dev libgirepository-2.0-dev libcairo2-dev
 
     - name: Set up Python 3.11
       uses: actions/setup-python@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,8 +22,8 @@ jobs:
 
     - name: Install OS package dependencies
       run: |
-        sudo apt update
-        sudo apt install libenchant-2-dev libbz2-dev libsnappy-dev libunwind-dev libgirepository-2.0-dev libcairo2-dev
+        sudo apt-get update
+        sudo apt-get -y install libenchant-2-dev libbz2-dev libsnappy-dev libunwind-dev libgirepository-2.0-dev libcairo2-dev
 
     - name: Set up Python 3.11
       uses: actions/setup-python@v3
@@ -76,8 +76,8 @@ jobs:
     #
     - name: Install OS package dependencies
       run: |
-        sudo apt update
-        sudo apt install build-essential libssl-dev libffi-dev libunwind-dev \
+        sudo apt-get update
+        sudo apt-get -y install build-essential libssl-dev libffi-dev libunwind-dev \
           libreadline-dev zlib1g-dev libbz2-dev libsqlite3-dev libncurses5-dev \
           libsnappy-dev libgirepository-2.0-dev libcairo2-dev
 
@@ -119,8 +119,8 @@ jobs:
 
     - name: Install OS package dependencies
       run: |
-        sudo apt update
-        sudo apt install libenchant-2-dev libbz2-dev libsnappy-dev libunwind-dev libgirepository-2.0-dev libcairo2-dev
+        sudo apt-get update
+        sudo apt-get -y install libenchant-2-dev libbz2-dev libsnappy-dev libunwind-dev libgirepository-2.0-dev libcairo2-dev
 
     - name: Set up Python 3.11
       uses: actions/setup-python@v3


### PR DESCRIPTION
Grmmm, I can't reopen #1658 because I force-pushed in between. I got a pretty good result, most job working.
Only test pypy-3.10 is failing, because a missing mdb.c file, at the installation of lmdb.
Since I noticed that zlmdb is a crossbar.io project, I thought you might be better informed than me on the problem.

Oh, btw, I took the liberty to change `apt` for `apt-get`, because there was warning: apt is a high level interface for humans, it's not for automation, and it's not meant to be stable in its interface as well.

```
Collecting lmdb>=1.4.0 (from zlmdb>=21.2.1->autobahn==24.4.2)
  Downloading lmdb-1.6.2.tar.gz (881 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 881.4/881.4 kB 83.8 MB/s eta 0:00:00
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'error'
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [74 lines of output]
      patching file lmdb.h
      patching file mdb.c
      cc1: fatal error: build/lib/mdb.c: No such file or directory
      ```