### PR TITLE
Plain twisted utilities are sufficient

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
       # WEB3_INFURA_PROJECT_ID: ${{ secrets.WEB3_INFURA_PROJECT_ID }}
       # WEB3_INFURA_API_SECRET: ${{ secrets.WEB3_INFURA_API_SECRET }}
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
 
@@ -52,12 +52,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04]
-        # os: [ubuntu-22.04, macos-latest, windows-latest]
+        os: [ubuntu-latest]
+        # os: [ubuntu-latest, macos-latest, windows-latest]
 
         # python 3.11 fails with "src/twisted/test/raiser.c:198:12: fatal error: longintrepr.h: No such file or directory"
         # twisted doesn't yet support 3.11 formally: https://github.com/twisted/twisted/blob/trunk/pyproject.toml#L24
-        python-version: ['3.9', '3.11', 'pypy-3.10']
+        python-version: ['3.9', '3.11', 'pypy-3.9']
         framework: ['asyncio', 'tw2403', 'twtrunk']
 
     # https://github.blog/changelog/2020-04-15-github-actions-new-workflow-features/
@@ -79,7 +79,8 @@ jobs:
         sudo apt update
         sudo apt install build-essential libssl-dev libffi-dev libunwind-dev \
           libreadline-dev zlib1g-dev libbz2-dev libsqlite3-dev libncurses5-dev \
-          libsnappy-dev libgirepository1.0-dev
+          libsnappy-dev libcairo2-dev libgirepository-2.0-dev \
+          build-essential python3-dev pypy3-dev libffi-dev
 
     # Use this Python
     # https://github.com/actions/setup-python/blob/main/README.md
@@ -113,14 +114,14 @@ jobs:
         tox -c tox.ini -e ${{ matrix.framework }}
 
   docs:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
 
     - name: Install OS package dependencies
       run: |
         sudo apt update
-        sudo apt install libenchant-2-dev libbz2-dev libsnappy-dev libunwind-dev libgirepository1.0-dev
+        sudo apt install libenchant-2-dev libbz2-dev libsnappy-dev libunwind-dev libcairo2-dev libgirepository-2.0-dev
 
     - name: Set up Python 3.11
       uses: actions/setup-python@v3

--- a/autobahn/asyncio/test/test_aio_rawsocket.py
+++ b/autobahn/asyncio/test/test_aio_rawsocket.py
@@ -11,7 +11,7 @@ from autobahn.wamp.types import TransportDetails
 
 
 @pytest.mark.skipif(not os.environ.get('USE_ASYNCIO', False), reason='test runs on asyncio only')
-def test_sers(event_loop):
+def test_sers():
     serializers = get_serializers()
     assert len(serializers) > 0
     m = serializers[0]().serialize(message.Abort('close'))
@@ -19,7 +19,7 @@ def test_sers(event_loop):
 
 
 @pytest.mark.skipif(not os.environ.get('USE_ASYNCIO', False), reason='test runs on asyncio only')
-def test_prefix(event_loop):
+def test_prefix():
     p = PrefixProtocol()
     transport = Mock()
     receiver = Mock()
@@ -62,7 +62,7 @@ def test_prefix(event_loop):
 
 
 @pytest.mark.skipif(not os.environ.get('USE_ASYNCIO', False), reason='test runs on asyncio only')
-def test_is_closed(event_loop):
+def test_is_closed():
     class CP(RawSocketClientProtocol):
         @property
         def serializer_id(self):
@@ -83,7 +83,7 @@ def test_is_closed(event_loop):
 
 
 @pytest.mark.skipif(not os.environ.get('USE_ASYNCIO', False), reason='test runs on asyncio only')
-def test_raw_socket_server1(event_loop):
+def test_raw_socket_server1():
 
     server = RawSocketServerProtocol()
     ser = Mock(return_value=True)
@@ -108,7 +108,7 @@ def test_raw_socket_server1(event_loop):
 
 
 @pytest.mark.skipif(not os.environ.get('USE_ASYNCIO', False), reason='test runs on asyncio only')
-def test_raw_socket_server_errors(event_loop):
+def test_raw_socket_server_errors():
 
     server = RawSocketServerProtocol()
     ser = Mock(return_value=True)
@@ -139,7 +139,7 @@ def test_raw_socket_server_errors(event_loop):
 
 
 @pytest.mark.skipif(not os.environ.get('USE_ASYNCIO', False), reason='test runs on asyncio only')
-def test_raw_socket_client1(event_loop):
+def test_raw_socket_client1():
     class CP(RawSocketClientProtocol):
         @property
         def serializer_id(self):
@@ -162,7 +162,7 @@ def test_raw_socket_client1(event_loop):
 
 
 @pytest.mark.skipif(not os.environ.get('USE_ASYNCIO', False), reason='test runs on asyncio only')
-def test_raw_socket_client_error(event_loop):
+def test_raw_socket_client_error():
     class CP(RawSocketClientProtocol):
         @property
         def serializer_id(self):
@@ -181,7 +181,7 @@ def test_raw_socket_client_error(event_loop):
 
 
 @pytest.mark.skipif(not os.environ.get('USE_ASYNCIO', False), reason='test runs on asyncio only')
-def test_wamp_server(event_loop):
+def test_wamp_server():
     transport = Mock(spec_set=('abort', 'close', 'write', 'get_extra_info'))
     transport.write = Mock(side_effect=lambda m: messages.append(m))
     server = Mock(spec=['onOpen', 'onMessage'])
@@ -209,7 +209,7 @@ def test_wamp_server(event_loop):
 
 
 @pytest.mark.skipif(not os.environ.get('USE_ASYNCIO', False), reason='test runs on asyncio only')
-def test_wamp_client(event_loop):
+def test_wamp_client():
     transport = Mock(spec_set=('abort', 'close', 'write', 'get_extra_info'))
     transport.write = Mock(side_effect=lambda m: messages.append(m))
     client = Mock(spec=['onOpen', 'onMessage'])

--- a/autobahn/asyncio/test/test_aio_websocket.py
+++ b/autobahn/asyncio/test/test_aio_websocket.py
@@ -22,15 +22,15 @@ async def test_echo_async():
 
 
 @pytest.mark.skipif(not os.environ.get('USE_ASYNCIO', False), reason='test runs on asyncio only')
-def test_websocket_custom_loop(event_loop):
-    factory = WebSocketServerFactory(loop=event_loop)
+def test_websocket_custom_loop():
+    factory = WebSocketServerFactory(loop=asyncio.new_event_loop())
     server = factory()
     transport = Mock()
     server.connection_made(transport)
 
 
 @pytest.mark.skipif(not os.environ.get('USE_ASYNCIO', False), reason='test runs on asyncio only')
-def test_async_on_connect_server(event_loop):
+def test_async_on_connect_server():
 
     num = 42
     done = txaio.create_future()
@@ -64,7 +64,7 @@ def test_async_on_connect_server(event_loop):
     ])
     server.processHandshake()
 
-    event_loop.run_until_complete(done)
+    asyncio.get_event_loop().run_until_complete(done)
 
     assert len(values) == 1
     assert values[0] == num * num

--- a/autobahn/twisted/test/test_tx_websocket_agent.py
+++ b/autobahn/twisted/test/test_tx_websocket_agent.py
@@ -1,12 +1,13 @@
 from twisted.trial import unittest
 
 try:
-    from autobahn.twisted.testing import create_memory_agent, MemoryReactorClockResolver, create_pumper
+    from autobahn.twisted.testing import create_memory_agent, create_pumper
     HAVE_TESTING = True
 except ImportError:
     HAVE_TESTING = False
 
 from twisted.internet.defer import inlineCallbacks
+from twisted.internet.testing import MemoryReactorClock
 from autobahn.twisted.websocket import WebSocketServerProtocol
 
 
@@ -16,7 +17,7 @@ class TestAgent(unittest.TestCase):
 
     def setUp(self):
         self.pumper = create_pumper()
-        self.reactor = MemoryReactorClockResolver()
+        self.reactor = MemoryReactorClock()
         return self.pumper.start()
 
     def tearDown(self):

--- a/autobahn/twisted/testing/__init__.py
+++ b/autobahn/twisted/testing/__init__.py
@@ -73,32 +73,9 @@ class _StaticTestResolver(object):
         receiver.resolutionComplete()
 
 
-@implementer(IReactorPluggableNameResolver)
-class _TestNameResolver(object):
-    """
-    A test version of IReactorPluggableNameResolver
-    """
-
-    _resolver = None
-
-    @property
-    def nameResolver(self):
-        if self._resolver is None:
-            self._resolver = _StaticTestResolver()
-        return self._resolver
-
-    def installNameResolver(self, resolver):
-        old = self._resolver
-        self._resolver = resolver
-        return old
-
-
-class MemoryReactorClockResolver(MemoryReactorClock, _TestNameResolver):
-    """
-    Combine MemoryReactor, Clock and an IReactorPluggableNameResolver
-    together.
-    """
-    pass
+# in previous revisions, we exported MemoryReactorClockResolver so
+# this maintains compatibility with any downstream code
+MemoryReactorClockResolver = MemoryReactorClock
 
 
 class _TwistedWebMemoryAgent(IWebSocketClientAgent):

--- a/autobahn/twisted/testing/__init__.py
+++ b/autobahn/twisted/testing/__init__.py
@@ -37,7 +37,7 @@ except ImportError:
 from twisted.internet.defer import Deferred
 from twisted.internet.address import IPv4Address
 from twisted.internet._resolver import HostResolution  # "internal" class, but it's simple
-from twisted.internet.interfaces import ISSLTransport, IReactorPluggableNameResolver
+from twisted.internet.interfaces import ISSLTransport
 try:
     from twisted.internet.testing import MemoryReactorClock
 except ImportError:

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,9 @@ envlist =
     sphinx
     py39-{tw2403,twtrunk,asyncio}
     py311-{tw2403,twtrunk,asyncio}
+    py312-{tw2403,twtrunk,asyncio}
     pypy39-{tw2403,twtrunk,asyncio}
+    pypy310-{tw2403,twtrunk,asyncio}
 
 
 # MAP: GitHub Actions Python Name => Tox Env Name (for Python)
@@ -19,7 +21,9 @@ envlist =
 python =
     3.9: py9
     3.11: py311
+    3.12: py312
     pypy-3.9: pypy39
+    pypy-3.10: pypy310
 
 
 [testenv]


### PR DESCRIPTION
Twisted 25.5.0 causes Autobahn's test reactor to fail -- but it turns out it's not really required and a fix for Twisted is to just remove this.