### PR TITLE
Use sysconfig.get_platform for machine detection

### DIFF
--- a/.audit/jameshilliard_sysconfig-machine.md
+++ b/.audit/jameshilliard_sysconfig-machine.md
@@ -1,0 +1,10 @@
+## AI Assistance Disclosure
+
+- [x] I did **not** use any AI-assistance tools to help create this pull request.
+- [ ] I **did** use AI-assistance tools to *help* create this pull request.
+- [x] I have read, understood and followed the projects' [AI Policy](https://github.com/crossbario/autobahn-python/blob/main/AI_POLICY.md) when creating code, documentation etc. for this pull request.
+
+Submitted by: @jameshilliard
+Date: 2026-01-01
+Related issue(s): #1834
+Branch: sysconfig-machine

--- a/src/autobahn/nvx/_compile_args.py
+++ b/src/autobahn/nvx/_compile_args.py
@@ -124,7 +124,7 @@ See Also
 
 import os
 import sys
-import platform
+import sysconfig
 
 
 def is_building_wheel():
@@ -194,7 +194,7 @@ def get_compile_args():
         return ["/O2", "/W3"]
 
     # GCC/Clang on POSIX (Linux, macOS, *BSD)
-    machine = platform.machine().lower()
+    machine = sysconfig.get_platform().lower().split("-")[-1]
 
     # Base flags for all POSIX platforms
     base_args = [
@@ -245,7 +245,7 @@ def _get_safe_march_flag(machine):
     Parameters
     ----------
     machine : str
-        Machine architecture from platform.machine().lower()
+        Machine architecture from sysconfig.get_platform().lower().split("-")[-1]
 
     Returns
     -------


### PR DESCRIPTION
This should function correctly when cross compiling unlike platform.machine.

## Description

Uses sysconfig to detect target architecture correctly.

---

## Related Issue(s)

Closes or relates to #1834

---

## Checklist

- [x] I have referenced relevant issue numbers above
- [x] I have performed a self-review of my code and it follows
      the style guidelines of this project
- [ ] I have added new or used existing tests that prove my fix
      is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate) and
      updated the changelog
- [x] I have added an AI assistance disclosure file (required!)
      in this PR
